### PR TITLE
feat: 알림 기능 추가 및 회원가입 마케팅 수신 동의 항목 추가

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -25,8 +25,8 @@ router = APIRouter()
 
 @router.post("/signup", response_model=SignUpResponse, status_code=201, summary="회원가입")
 def api_signup(body: SignUpRequest, db: Session = Depends(get_db)):
-    user = signup(email=body.email, nickname=body.nickname, password=body.password, db=db)
-    return SignUpResponse(id=user.id, email=user.email, nickname=user.nickname, created_at=user.created_at)
+    user = signup(email=body.email, nickname=body.nickname, password=body.password, db=db, marketing_agreed=body.marketing_agreed)
+    return SignUpResponse(id=user.id, email=user.email, nickname=user.nickname, marketing_agreed=user.marketing_agreed, created_at=user.created_at)
 
 
 @router.post("/login", summary="로그인 (Swagger 자물쇠 겸용)")
@@ -51,6 +51,7 @@ def api_my_info(user: User = Depends(get_current_user)):
         email=user.email,
         nickname=user.nickname,
         has_password=user.password_hash is not None,
+        marketing_agreed=user.marketing_agreed,
         created_at=user.created_at,
         updated_at=user.updated_at,
     )
@@ -64,6 +65,7 @@ def api_update_nickname(body: UpdateNicknameRequest, user: User = Depends(get_cu
         email=updated.email,
         nickname=updated.nickname,
         has_password=updated.password_hash is not None,
+        marketing_agreed=updated.marketing_agreed,
         created_at=updated.created_at,
         updated_at=updated.updated_at,
     )

--- a/app/api/v1/notifications.py
+++ b/app/api/v1/notifications.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+from app.db.session import get_db
+from app.core.security import get_current_user
+from app.models.user import User
+from app.schemas.notification import (
+    NotificationGroupResponse,
+    NotificationListResponse,
+    NotificationReadResponse,
+    NotificationResponse,
+)
+from app.services.notification_service import (
+    get_notifications_grouped,
+    get_notifications,
+    get_unread_count,
+    mark_as_read,
+    mark_all_as_read,
+)
+
+router = APIRouter()
+
+
+@router.get("/grouped", response_model=NotificationGroupResponse, summary="알림 그룹별 조회 (Today / This Week)")
+def api_get_notifications_grouped(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return get_notifications_grouped(user_id=user.id, db=db)
+
+
+@router.get("", response_model=NotificationListResponse, summary="알림 전체 조회")
+def api_get_notifications(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    total, unread_count, notifications = get_notifications(user_id=user.id, db=db, skip=skip, limit=limit)
+    return NotificationListResponse(total=total, unread_count=unread_count, notifications=notifications)
+
+
+@router.get("/unread-count", summary="읽지 않은 알림 수")
+def api_get_unread_count(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return {"unread_count": get_unread_count(user_id=user.id, db=db)}
+
+
+@router.patch("/{notification_id}/read", response_model=NotificationResponse, summary="알림 읽음 처리")
+def api_mark_as_read(
+    notification_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return mark_as_read(notification_id=notification_id, user_id=user.id, db=db)
+
+
+@router.patch("/read-all", response_model=NotificationReadResponse, summary="전체 알림 읽음 처리")
+def api_mark_all_as_read(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    count = mark_all_as_read(user_id=user.id, db=db)
+    return NotificationReadResponse(message=f"{count}개의 알림을 읽음 처리했습니다.")

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -1,5 +1,5 @@
 from app.db.session import engine, Base
-from app.models import user, contract, analysis, chat, social_account  # noqa: F401
+from app.models import user, contract, analysis, chat, social_account, notification  # noqa: F401
 
 
 def init_db():

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from app.db.init_db import init_db
 from app.api.v1.auth import router as auth_router
 from app.api.v1.contracts import router as contracts_router
 from app.api.v1.chat import router as chat_router
+from app.api.v1.notifications import router as notifications_router
 
 
 @asynccontextmanager
@@ -29,6 +30,7 @@ app.add_middleware(
 app.include_router(auth_router, prefix="/api/v1/auth", tags=["인증"])
 app.include_router(contracts_router, prefix="/api/v1/contracts", tags=["계약서"])
 app.include_router(chat_router, prefix="/api/v1/chat", tags=["채팅"])
+app.include_router(notifications_router, prefix="/api/v1/notifications", tags=["알림"])
 
 
 @app.get("/health", tags=["시스템"])

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,3 +2,4 @@ from app.models.user import User
 from app.models.contract import Contract
 from app.models.analysis import AnalysisResult, RiskClause
 from app.models.chat import ChatSession, ChatMessage
+from app.models.notification import Notification

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import enum
+from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, Enum, func
+from sqlalchemy.orm import relationship
+from app.db.session import Base
+
+
+class NotificationType(str, enum.Enum):
+    ANALYSIS_COMPLETE = "analysis_complete"
+    ANALYSIS_FAILED = "analysis_failed"
+    SYSTEM = "system"
+    MARKETING = "marketing"
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    notification_type = Column(Enum(NotificationType), nullable=False, default=NotificationType.SYSTEM)
+    title = Column(String(255), nullable=False)
+    content = Column(Text, nullable=True)
+    is_read = Column(Boolean, nullable=False, default=False, server_default="0")
+    contract_id = Column(Integer, ForeignKey("contracts.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime, server_default=func.now())
+
+    user = relationship("User", backref="notifications")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, func
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, func
 from sqlalchemy.orm import relationship
 from app.db.session import Base
 
@@ -10,6 +10,7 @@ class User(Base):
     nickname = Column(String(100), nullable=False)
     password_hash = Column(String(255), nullable=True)
     created_at = Column(DateTime, server_default=func.now())
+    marketing_agreed = Column(Boolean, nullable=False, default=False, server_default="0")
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
 
     contracts = relationship("Contract", back_populates="user", cascade="all, delete-orphan")

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -8,6 +8,7 @@ class SignUpRequest(BaseModel):
     nickname: str
     password: str
     password_confirm: str
+    marketing_agreed: bool = False
 
     @field_validator("nickname")
     @classmethod
@@ -35,6 +36,7 @@ class SignUpResponse(BaseModel):
     id: int
     email: str
     nickname: str
+    marketing_agreed: bool
     created_at: datetime
     message: str = "회원가입이 완료되었습니다."
     model_config = {"from_attributes": True}
@@ -75,6 +77,7 @@ class MyInfoResponse(BaseModel):
     email: str
     nickname: str
     has_password: bool
+    marketing_agreed: bool
     created_at: datetime
     updated_at: datetime
     model_config = {"from_attributes": True}

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime
+
+
+class NotificationResponse(BaseModel):
+    id: int
+    notification_type: str
+    title: str
+    content: Optional[str] = None
+    is_read: bool
+    contract_id: Optional[int] = None
+    created_at: datetime
+    model_config = {"from_attributes": True}
+
+
+class NotificationGroupResponse(BaseModel):
+    """Today / This week 그룹별 알림 응답"""
+    today: List[NotificationResponse]
+    this_week: List[NotificationResponse]
+    today_count: int
+    this_week_count: int
+
+
+class NotificationListResponse(BaseModel):
+    total: int
+    unread_count: int
+    notifications: List[NotificationResponse]
+
+
+class NotificationReadResponse(BaseModel):
+    message: str

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -9,11 +9,11 @@ from app.models.user import User
 from app.models.social_account import SocialAccount
 
 
-def signup(email: str, nickname: str, password: str, db: Session) -> User:
+def signup(email: str, nickname: str, password: str, db: Session, marketing_agreed: bool = False) -> User:
     existing = db.query(User).filter(User.email == email).first()
     if existing:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="이미 가입된 이메일입니다.")
-    user = User(email=email, nickname=nickname.strip(), password_hash=hash_password(password))
+    user = User(email=email, nickname=nickname.strip(), password_hash=hash_password(password), marketing_agreed=marketing_agreed)
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/app/services/contract_service.py
+++ b/app/services/contract_service.py
@@ -17,6 +17,8 @@ from app.integrations.mappers import (
     ai_risks_to_risk_clauses,
     ai_analysis_to_analysis_result,
 )
+from app.models.notification import NotificationType
+from app.services.notification_service import create_notification
 
 
 def _validate_file(file: UploadFile) -> None:
@@ -177,6 +179,15 @@ async def analyze_contract_background(contract_id: int) -> None:
         contract.analysis_completed_at = datetime.now(timezone.utc)
         db.commit()
 
+        # 분석 완료 알림
+        create_notification(
+            user_id=contract.user_id,
+            title=f"'{contract.original_filename}' 분석이 완료되었습니다.",
+            db=db,
+            notification_type=NotificationType.ANALYSIS_COMPLETE,
+            contract_id=contract.id,
+        )
+
     except Exception as e:
         db.rollback()
         # 실패 사유를 DB에 기록 — 프론트가 GET /status로 확인 가능
@@ -185,5 +196,14 @@ async def analyze_contract_background(contract_id: int) -> None:
             contract.status = ContractStatus.FAILED
             contract.analysis_error = str(e)
             db.commit()
+            # 분석 실패 알림
+            create_notification(
+                user_id=contract.user_id,
+                title=f"'{contract.original_filename}' 분석에 실패했습니다.",
+                db=db,
+                notification_type=NotificationType.ANALYSIS_FAILED,
+                content=str(e),
+                contract_id=contract.id,
+            )
     finally:
         db.close()  # BackgroundTask는 request 생명주기 밖이므로 반드시 명시적으로 닫아야 함

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from sqlalchemy.orm import Session
+from app.models.notification import Notification, NotificationType
+
+
+def create_notification(
+    user_id: int,
+    title: str,
+    db: Session,
+    notification_type: NotificationType = NotificationType.SYSTEM,
+    content: Optional[str] = None,
+    contract_id: Optional[int] = None,
+) -> Notification:
+    noti = Notification(
+        user_id=user_id,
+        notification_type=notification_type,
+        title=title,
+        content=content,
+        contract_id=contract_id,
+    )
+    db.add(noti)
+    db.commit()
+    db.refresh(noti)
+    return noti
+
+
+def get_notifications_grouped(user_id: int, db: Session) -> dict:
+    """Today / This week 그룹으로 나눠서 반환."""
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    week_start = today_start - timedelta(days=today_start.weekday())
+
+    all_noti = (
+        db.query(Notification)
+        .filter(Notification.user_id == user_id, Notification.created_at >= week_start)
+        .order_by(Notification.created_at.desc())
+        .all()
+    )
+
+    today = []
+    this_week = []
+    for n in all_noti:
+        created = n.created_at
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        if created >= today_start:
+            today.append(n)
+        else:
+            this_week.append(n)
+
+    return {
+        "today": today,
+        "this_week": this_week,
+        "today_count": len(today),
+        "this_week_count": len(this_week),
+    }
+
+
+def get_notifications(user_id: int, db: Session, skip: int = 0, limit: int = 50) -> tuple:
+    query = db.query(Notification).filter(Notification.user_id == user_id)
+    total = query.count()
+    unread_count = query.filter(Notification.is_read == False).count()  # noqa: E712
+    notifications = query.order_by(Notification.created_at.desc()).offset(skip).limit(limit).all()
+    return total, unread_count, notifications
+
+
+def get_unread_count(user_id: int, db: Session) -> int:
+    return (
+        db.query(Notification)
+        .filter(Notification.user_id == user_id, Notification.is_read == False)  # noqa: E712
+        .count()
+    )
+
+
+def mark_as_read(notification_id: int, user_id: int, db: Session) -> Notification:
+    noti = (
+        db.query(Notification)
+        .filter(Notification.id == notification_id, Notification.user_id == user_id)
+        .first()
+    )
+    if not noti:
+        from fastapi import HTTPException, status
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="알림을 찾을 수 없습니다.")
+    noti.is_read = True
+    db.commit()
+    db.refresh(noti)
+    return noti
+
+
+def mark_all_as_read(user_id: int, db: Session) -> int:
+    count = (
+        db.query(Notification)
+        .filter(Notification.user_id == user_id, Notification.is_read == False)  # noqa: E712
+        .update({"is_read": True})
+    )
+    db.commit()
+    return count


### PR DESCRIPTION
## 관련 이슈
Closes #12

## 개요
회원가입 시 마케팅 수신 동의 항목 추가 및 알림(Notification) 기능 구현

## 변경 사항
- **User 모델**: `marketing_agreed` 필드 추가
- **회원가입**: 마케팅 수신 동의 체크 옵션 추가
- **내 정보 조회**: `MyInfoResponse`에 `marketing_agreed` 포함
- **Notification 모델**: `notifications` 테이블 신규 생성
- **알림 서비스**: 생성, 조회(그룹별/전체), 읽음 처리, 전체 읽음 처리
- **알림 API 엔드포인트**:
  - `GET /notifications/grouped` - Today / This Week 그룹별 조회
  - `GET /notifications` - 전체 조회 (페이징)
  - `GET /notifications/unread-count` - 읽지 않은 알림 수
  - `PATCH /notifications/{id}/read` - 개별 읽음 처리
  - `PATCH /notifications/read-all` - 전체 읽음 처리
- **분석 연동**: 계약서 분석 완료/실패 시 알림 자동 생성

## 테스트 방법
- [x] 회원가입 시 marketing_agreed: true 전달 확인
- [ ] GET /notifications/grouped에서 Today / This Week 그룹 응답 확인
- [ ] 알림 읽음 처리 후 unread_count 감소 확인
- [ ] 계약서 분석 완료 시 알림 자동 생성 확인

