### PR TITLE
feat: 법령 준수 검사 결과 DB 저장 연동

### DIFF
--- a/app/integrations/ai_models.py
+++ b/app/integrations/ai_models.py
@@ -66,7 +66,29 @@ class AIAnalysisResponse(BaseModel):
     detected_objects: list[AIVisionObject] = []
     ocr_raw_text: str = ""              # OCR 원문 (정제 전)
     ocr_pages: list[dict] = []          # [{page_index, text}] 페이지별 텍스트
+    compliance: list[AIComplianceResult] = []  # 법령 준수 검사 결과
 
+
+# 법령 준수 검사 근거 법령 1건
+class AILawReference(BaseModel):
+    law_name: str           # ex) "근로기준법"
+    article_no: str         # ex) "제56조"
+    article_title: str      # ex) "연장·야간 및 휴일 근로"
+    content: str            # 조문 내용
+    similarity: float = 0.0 # 벡터 유사도 점수
+
+
+# 법령 준수 검사 결과 1건 (조항 단위)
+class AIComplianceResult(BaseModel):
+    clause_id: str                          # ContractClause.clause_id 참조
+    clause_title: Optional[str] = None
+    clause_text: str
+    status: str                             # "위반" | "주의" | "적합" | "검토불가"
+    reason: str                             # 판단 이유
+    law_references: list[AILawReference] = []
+
+
+# POST /analyze 전체 응답에 compliance 필드 추가됨 (하단 AIAnalysisResponse 참조)
 
 # POST /qa 응답 — 질의응답 결과
 class AIQAResponse(BaseModel):

--- a/app/integrations/mappers.py
+++ b/app/integrations/mappers.py
@@ -6,9 +6,9 @@ AI 응답 → ORM 객체 변환 순수 함수 모음.
 DB I/O 없음. 변환 로직만 담당.
 서비스 레이어가 이 함수들을 호출해 ORM 객체를 만든 뒤 db.add()한다.
 """
-from app.integrations.ai_models import AIAnalysisResponse, AIRiskResult, AIClause
+from app.integrations.ai_models import AIAnalysisResponse, AIRiskResult, AIClause, AIComplianceResult
 from app.models.contract import ContractType
-from app.models.analysis import AnalysisResult, RiskClause, ContractClause, RiskLevel
+from app.models.analysis import AnalysisResult, RiskClause, ContractClause, RiskLevel, ComplianceResult
 
 # clair-ai가 반환하는 contract_type 문자열 → ContractType Enum 변환 테이블
 # AI 출력값이 추가될 경우 여기에만 추가하면 됨
@@ -71,6 +71,25 @@ def ai_risks_to_risk_clauses(risks: list[AIRiskResult], contract_id: int) -> lis
             )
         )
     return rows
+
+
+def ai_compliance_to_compliance_results(
+    compliance: list[AIComplianceResult],
+    contract_id: int,
+) -> list[ComplianceResult]:
+    """AIComplianceResult 리스트 → ComplianceResult ORM 객체 리스트."""
+    return [
+        ComplianceResult(
+            contract_id=contract_id,
+            clause_id=c.clause_id,
+            clause_title=c.clause_title,
+            clause_text=c.clause_text,
+            status=c.status,
+            reason=c.reason,
+            law_references=[ref.model_dump() for ref in c.law_references],
+        )
+        for c in compliance
+    ]
 
 
 def ai_analysis_to_analysis_result(

--- a/app/models/analysis.py
+++ b/app/models/analysis.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Text, JSON, ForeignKey, Enum, func, UniqueConstraint
+from sqlalchemy import Column, Integer, String, DateTime, Text, JSON, ForeignKey, Enum, Float, func, UniqueConstraint
 from sqlalchemy.orm import relationship
 import enum
 from app.db.session import Base
@@ -95,3 +95,26 @@ class RiskClause(Base):
     created_at = Column(DateTime, server_default=func.now())
 
     contract = relationship("Contract", back_populates="risk_clauses")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ComplianceResult: 조항별 법령 준수 검사 결과
+# clair-ai /analyze 응답의 compliance[] 배열을 행 단위로 저장
+# ──────────────────────────────────────────────────────────────────────────────
+class ComplianceResult(Base):
+    __tablename__ = "compliance_results"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    contract_id = Column(Integer, ForeignKey("contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    # ContractClause.clause_id 참조 — 프론트에서 조항 하이라이트에 사용
+    clause_id = Column(String(50), nullable=False)
+    clause_title = Column(String(500), nullable=True)
+    clause_text = Column(Text, nullable=False)
+    # 준수 상태: 위반 | 주의 | 적합 | 검토불가
+    status = Column(String(20), nullable=False)
+    reason = Column(Text, nullable=True)
+    # 근거 법령 목록 JSON ex) [{"law_name": "근로기준법", "article_no": "제56조", ...}]
+    law_references = Column(JSON, nullable=True)
+    created_at = Column(DateTime, server_default=func.now())
+
+    contract = relationship("Contract", back_populates="compliance_results")

--- a/app/models/contract.py
+++ b/app/models/contract.py
@@ -78,3 +78,5 @@ class Contract(Base):
     risk_clauses = relationship("RiskClause", back_populates="contract", cascade="all, delete-orphan")
     # 계약 조항 (1:N 관계)
     clauses = relationship("ContractClause", back_populates="contract", cascade="all, delete-orphan")
+    # 법령 준수 검사 결과 (1:N 관계)
+    compliance_results = relationship("ComplianceResult", back_populates="contract", cascade="all, delete-orphan")

--- a/app/services/contract_service.py
+++ b/app/services/contract_service.py
@@ -9,13 +9,14 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.db.session import SessionLocal
 from app.models.contract import Contract, ContractStatus
-from app.models.analysis import AnalysisResult, RiskClause, ContractClause
+from app.models.analysis import AnalysisResult, RiskClause, ContractClause, ComplianceResult
 from app.integrations.ai_client import ai_client
 from app.integrations.mappers import (
     ai_contract_type_to_enum,
     ai_clauses_to_contract_clauses,
     ai_risks_to_risk_clauses,
     ai_analysis_to_analysis_result,
+    ai_compliance_to_compliance_results,
 )
 from app.models.notification import NotificationType
 from app.services.notification_service import create_notification
@@ -158,6 +159,7 @@ async def analyze_contract_background(contract_id: int) -> None:
         db.query(AnalysisResult).filter(AnalysisResult.contract_id == contract_id).delete()
         db.query(RiskClause).filter(RiskClause.contract_id == contract_id).delete()
         db.query(ContractClause).filter(ContractClause.contract_id == contract_id).delete()
+        db.query(ComplianceResult).filter(ComplianceResult.contract_id == contract_id).delete()
 
         # 조항 먼저 저장 — RiskClause.evidence_clause_ids가 이 clause_id를 참조하므로 순서 중요
         clause_rows = ai_clauses_to_contract_clauses(ai_resp.clauses, contract_id)
@@ -170,6 +172,11 @@ async def analyze_contract_background(contract_id: int) -> None:
         # 위험 조항 저장
         risk_rows = ai_risks_to_risk_clauses(ai_resp.risks, contract_id)
         db.add_all(risk_rows)
+
+        # 법령 준수 검사 결과 저장
+        if ai_resp.compliance:
+            compliance_rows = ai_compliance_to_compliance_results(ai_resp.compliance, contract_id)
+            db.add_all(compliance_rows)
 
         # 계약서 상태 업데이트
         contract.status = ContractStatus.COMPLETED


### PR DESCRIPTION
## 관련 이슈
Closes #14 

## 개요
clair-ai의 법령 준수 검사(compliance) 결과를 clair-backend DB에 저장하는 연동 구현

## 변경 사항
- **AIComplianceResult, AILawReference**: clair-ai 응답 파싱용 Pydantic 스키마 추가 (`ai_models.py`)
- **ComplianceResult 모델**: `compliance_results` 테이블 신규 생성 (`models/analysis.py`)
  - `clause_id`, `status`(위반/주의/적합/검토불가), `reason`, `law_references`(JSON) 저장
- **Contract 모델**: `compliance_results` 관계 추가, cascade delete 설정
- **mappers.py**: `ai_compliance_to_compliance_results()` 변환 함수 추가
- **contract_service.py**: 분석 백그라운드 태스크에 compliance 저장/재분석 초기화 로직 추가

## 테스트 방법
- [x] 계약서 분석 완료 후 `SELECT * FROM compliance_results WHERE contract_id={id}` 확인
- [ ] 재분석 시 기존 compliance 결과 초기화 후 재저장 확인