### PR TITLE
feat: 계약서 분석 결과 공유 및 PDF 다운로드 기능 추가

### DIFF
--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, Depends, UploadFile, File, Query, BackgroundTasks
+from fastapi.responses import Response
 from sqlalchemy.orm import Session
+from urllib.parse import quote
 from app.db.session import get_db
 from app.core.security import get_current_user
 from app.models.user import User
@@ -8,10 +10,18 @@ from app.schemas.contract import (
     AnalysisResultResponse, RiskClauseResponse, MessageResponse,
     AnalyzeAcceptedResponse, ContractStatusResponse, ClauseResponse, ClauseListResponse,
 )
+from app.schemas.share import (
+    ShareCreateRequest, ShareCreateResponse,
+    ShareListItem, ShareListResponse,
+)
 from app.services.contract_service import (
     upload_contract, get_contract_by_id, get_contracts_by_user, delete_contract,
     trigger_analysis, analyze_contract_background, get_clauses,
 )
+from app.services.share_service import (
+    create_share, list_shares, revoke_share, share_to_response_dict,
+)
+from app.services.pdf_service import generate_contract_pdf
 
 router = APIRouter()
 
@@ -96,4 +106,53 @@ def api_get_clauses(contract_id: int, user: User = Depends(get_current_user), db
         total=len(clauses),
         clauses=[ClauseResponse(id=c.id, clause_id=c.clause_id, title=c.title, text=c.text,
                                 page_refs=c.page_refs, order=c.order) for c in clauses],
+    )
+
+
+# ── 공유 (소유자 전용) ─────────────────────────────────────────────────────
+
+@router.post("/{contract_id}/share", response_model=ShareCreateResponse, status_code=201, summary="공유 링크 생성")
+def api_create_share(
+    contract_id: int,
+    body: ShareCreateRequest,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    share = create_share(
+        contract_id=contract_id, user_id=user.id,
+        password=body.password, expire_days=body.expire_days, db=db,
+    )
+    return ShareCreateResponse(**share_to_response_dict(share))
+
+
+@router.get("/{contract_id}/shares", response_model=ShareListResponse, summary="공유 링크 목록")
+def api_list_shares(contract_id: int, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    shares = list_shares(contract_id=contract_id, user_id=user.id, db=db)
+    return ShareListResponse(
+        contract_id=contract_id,
+        total=len(shares),
+        shares=[ShareListItem(**share_to_response_dict(s)) for s in shares],
+    )
+
+
+@router.delete("/{contract_id}/shares/{share_id}", response_model=MessageResponse, summary="공유 링크 해제")
+def api_revoke_share(
+    contract_id: int, share_id: int,
+    user: User = Depends(get_current_user), db: Session = Depends(get_db),
+):
+    revoke_share(share_id=share_id, contract_id=contract_id, user_id=user.id, db=db)
+    return MessageResponse(message="공유 링크가 해제되었습니다.")
+
+
+# ── PDF 다운로드 (소유자 전용) ─────────────────────────────────────────────
+
+@router.get("/{contract_id}/download/pdf", summary="분석 결과 PDF 다운로드")
+def api_download_pdf(contract_id: int, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    pdf_bytes, filename = generate_contract_pdf(contract_id=contract_id, user_id=user.id, db=db)
+    # 한글 파일명은 RFC 5987 형식(`filename*`)으로 인코딩 — Content-Disposition에서 안전
+    content_disposition = f"attachment; filename*=UTF-8''{quote(filename)}"
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": content_disposition},
     )

--- a/app/api/v1/shares.py
+++ b/app/api/v1/shares.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy.orm import Session
+from app.db.session import get_db
+from app.schemas.share import (
+    ShareVerifyRequest, ShareVerifyResponse,
+    SharedContractResponse, SharedAnalysisResult, SharedRiskClause,
+)
+from app.services.share_service import verify_share_password, get_shared_contract
+
+
+router = APIRouter()
+
+
+@router.post("/{token}/verify", response_model=ShareVerifyResponse, summary="공유 비밀번호 검증")
+def api_verify_share(token: str, body: ShareVerifyRequest, db: Session = Depends(get_db)):
+    access_token, expires_at = verify_share_password(token=token, password=body.password, db=db)
+    return ShareVerifyResponse(access_token=access_token, expires_at=expires_at)
+
+
+def _bearer_token(authorization: str = Header(default="")) -> str:
+    """Authorization 헤더에서 Bearer 토큰만 뽑아내는 헬퍼."""
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="공유 access token이 필요합니다.")
+    return authorization.split(" ", 1)[1].strip()
+
+
+@router.get("/{token}", response_model=SharedContractResponse, summary="공유받은 계약서 분석 결과 조회")
+def api_get_shared_contract(
+    token: str,  # URL의 토큰은 검증 토큰과 일치해야 함
+    db: Session = Depends(get_db),
+    authorization: str = Header(default=""),
+):
+    """
+    헤더 'Authorization: Bearer <access_token>' 필요.
+    /verify로 받은 access_token을 그대로 사용.
+    공유받은 사람에게 노출되는 데이터: 분석 결과 + 위험 조항 + 근거.
+    """
+    access_token = _bearer_token(authorization)
+    share, contract = get_shared_contract(access_token, db)
+
+    # URL의 token과 access_token에 담긴 share_token이 일치하는지 추가 검증
+    if share.token != token:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="토큰 불일치")
+
+    analysis = None
+    if contract.analysis_result:
+        analysis = SharedAnalysisResult(
+            key_info=contract.analysis_result.key_info,
+            summary=contract.analysis_result.summary,
+        )
+
+    risk_clauses = [
+        SharedRiskClause(
+            clause_number=rc.clause_number,
+            risk_type=rc.risk_type,
+            risk_level=rc.risk_level.value,
+            explanation=rc.explanation,
+            evidence_clause_ids=rc.evidence_clause_ids,
+            evidence_text=rc.evidence_text,
+        )
+        for rc in (contract.risk_clauses or [])
+    ]
+
+    return SharedContractResponse(
+        contract_id=contract.id,
+        original_filename=contract.original_filename,
+        contract_type=contract.contract_type.value,
+        analysis=analysis,
+        risk_clauses=risk_clauses,
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -38,6 +38,11 @@ class Settings(BaseSettings):
     kakao_client_secret: str = ""
     kakao_redirect_uri: str = "http://localhost:8000/api/v1/auth/kakao/callback"
 
+    frontend_base_url: str = "http://localhost:5173"
+    share_path: str = "/share"
+    share_token_default_expire_days: int = 7
+    share_access_token_expire_minutes: int = 60
+
     @property
     def database_url(self) -> str:
         return f"mysql+pymysql://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}?charset=utf8mb4"
@@ -54,7 +59,7 @@ class Settings(BaseSettings):
     def cors_origins_list(self) -> List[str]:
         return [origin.strip() for origin in self.cors_origins.split(",")]
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
 
 settings = Settings()

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -32,6 +32,24 @@ def create_refresh_token(user_id: int) -> str:
     return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
 
 
+def create_share_access_token(share_token: str) -> tuple[str, datetime]:
+    """공유 링크 비밀번호 검증 통과 시 발급 — 짧은 만료(기본 60분)."""
+    expire = datetime.now(timezone.utc) + timedelta(minutes=settings.share_access_token_expire_minutes)
+    payload = {"share_token": share_token, "type": "share", "exp": expire}
+    return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm), expire
+
+
+def decode_share_access_token(jwt_str: str) -> str:
+    """공유 access token에서 share_token(원본 토큰) 추출. 검증 실패 시 401."""
+    payload = decode_token(jwt_str)
+    if payload.get("type") != "share":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="공유 access token이 아닙니다.")
+    share_token = payload.get("share_token")
+    if not share_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="유효하지 않은 토큰입니다.")
+    return share_token
+
+
 def decode_token(token: str) -> dict:
     try:
         return jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -1,5 +1,5 @@
 from app.db.session import engine, Base
-from app.models import user, contract, analysis, chat, social_account, notification  # noqa: F401
+from app.models import user, contract, analysis, chat, social_account, notification, contract_share  # noqa: F401
 
 
 def init_db():

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from app.api.v1.auth import router as auth_router
 from app.api.v1.contracts import router as contracts_router
 from app.api.v1.chat import router as chat_router
 from app.api.v1.notifications import router as notifications_router
+from app.api.v1.shares import router as shares_router
 
 
 @asynccontextmanager
@@ -31,6 +32,7 @@ app.include_router(auth_router, prefix="/api/v1/auth", tags=["인증"])
 app.include_router(contracts_router, prefix="/api/v1/contracts", tags=["계약서"])
 app.include_router(chat_router, prefix="/api/v1/chat", tags=["채팅"])
 app.include_router(notifications_router, prefix="/api/v1/notifications", tags=["알림"])
+app.include_router(shares_router, prefix="/api/v1/shares", tags=["공유 (외부 접근)"])
 
 
 @app.get("/health", tags=["시스템"])

--- a/app/models/contract_share.py
+++ b/app/models/contract_share.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, func
+from sqlalchemy.orm import relationship
+from app.db.session import Base
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ContractShare: 계약서 분석 결과 외부 공유용 토큰 + 비번
+#
+# 발급 시 raw token은 응답으로 한 번만 반환되고, DB엔 token만 저장한다.
+# password_hash는 bcrypt 해시 저장 — 검증 시 평문 비교 X.
+# revoked_at이 채워져 있으면 만료 전이라도 접근 차단.
+# ──────────────────────────────────────────────────────────────────────────────
+class ContractShare(Base):
+    __tablename__ = "contract_shares"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    contract_id = Column(Integer, ForeignKey("contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    token = Column(String(64), unique=True, nullable=False, index=True)
+    password_hash = Column(String(255), nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    revoked_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, server_default=func.now())
+
+    contract = relationship("Contract", backref="shares")

--- a/app/schemas/share.py
+++ b/app/schemas/share.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Optional
+from pydantic import BaseModel, Field
+
+
+# ── 공유 생성 / 목록 / 해제 (소유자) ─────────────────────────────────────────
+
+class ShareCreateRequest(BaseModel):
+    password: str = Field(min_length=4, description="공유받은 사람이 입력할 비밀번호 (4자 이상)")
+    expire_days: Optional[int] = Field(default=None, ge=1, le=30, description="만료일 (1~30일, 미지정 시 기본 7일)")
+
+
+class ShareCreateResponse(BaseModel):
+    id: int
+    token: str
+    share_url: str
+    expires_at: datetime
+    created_at: datetime
+    model_config = {"from_attributes": True}
+
+
+class ShareListItem(BaseModel):
+    id: int
+    token: str
+    share_url: str
+    expires_at: datetime
+    revoked_at: Optional[datetime] = None
+    created_at: datetime
+    is_active: bool
+    model_config = {"from_attributes": True}
+
+
+class ShareListResponse(BaseModel):
+    contract_id: int
+    total: int
+    shares: List[ShareListItem]
+
+
+# ── 공유받은 사람용 (비로그인) ──────────────────────────────────────────────
+
+class ShareVerifyRequest(BaseModel):
+    password: str
+
+
+class ShareVerifyResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_at: datetime
+
+
+class SharedRiskClause(BaseModel):
+    clause_number: Optional[str] = None
+    risk_type: str
+    risk_level: str
+    explanation: Optional[str] = None
+    evidence_clause_ids: Optional[List[str]] = None
+    evidence_text: Optional[str] = None
+    model_config = {"from_attributes": True}
+
+
+class SharedAnalysisResult(BaseModel):
+    key_info: Optional[Any] = None
+    summary: Optional[str] = None
+
+
+class SharedContractResponse(BaseModel):
+    """공유받은 사람에게 노출되는 데이터 — 분석 결과 + 위험 조항 + 근거만."""
+    contract_id: int
+    original_filename: str
+    contract_type: str
+    analysis: Optional[SharedAnalysisResult] = None
+    risk_clauses: List[SharedRiskClause] = []

--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+"""
+PDF 보고서 생성 서비스.
+
+WeasyPrint(HTML→PDF)를 사용해 Jinja2 템플릿으로 한국어 분석 보고서를 만든다.
+
+주의 (macOS):
+  weasyprint은 시스템 라이브러리(pango, glib)를 동적 로드하는데,
+  macOS SIP가 자식 프로세스에서 DYLD_* 환경변수를 제거한다.
+  cffi/dlopen은 import 시점에 env를 읽으므로, weasyprint import 전에
+  homebrew 라이브러리 경로를 명시 설정해야 한다.
+"""
+import os
+import platform
+from datetime import datetime
+from pathlib import Path
+
+# WeasyPrint import 전에 macOS 라이브러리 경로 설정 — 순서 중요
+if platform.system() == "Darwin":
+    for _hb in ("/opt/homebrew/lib", "/usr/local/lib"):  # Apple Silicon → Intel 순
+        if os.path.exists(_hb):
+            existing = os.environ.get("DYLD_FALLBACK_LIBRARY_PATH", "")
+            if _hb not in existing:
+                os.environ["DYLD_FALLBACK_LIBRARY_PATH"] = f"{_hb}:{existing}".rstrip(":")
+            break
+
+from fastapi import HTTPException, status
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from sqlalchemy.orm import Session
+from weasyprint import HTML
+
+from app.models.contract import Contract, ContractStatus
+from app.models.analysis import ContractClause
+
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates" / "pdf"
+_jinja_env = Environment(
+    loader=FileSystemLoader(_TEMPLATE_DIR),
+    autoescape=select_autoescape(["html"]),
+)
+
+
+_RISK_LEVEL_LABELS = {"high": "높음", "medium": "보통", "low": "낮음"}
+
+
+def generate_contract_pdf(contract_id: int, user_id: int, db: Session) -> tuple[bytes, str]:
+    """
+    소유자용 PDF 다운로드. 분석 완료된 계약서만 생성 가능.
+    반환: (PDF 바이트, 다운로드 파일명)
+    """
+    contract = db.query(Contract).filter(
+        Contract.id == contract_id, Contract.user_id == user_id
+    ).first()
+    if not contract:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="계약서를 찾을 수 없습니다.")
+    if contract.status != ContractStatus.COMPLETED:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="분석이 완료된 계약서만 PDF로 다운로드할 수 있습니다.")
+
+    clauses = (
+        db.query(ContractClause)
+        .filter(ContractClause.contract_id == contract_id)
+        .order_by(ContractClause.order)
+        .all()
+    )
+
+    risk_clauses = [
+        {
+            "clause_number": rc.clause_number,
+            "risk_type": rc.risk_type,
+            "risk_level": rc.risk_level.value,
+            "risk_level_label": _RISK_LEVEL_LABELS.get(rc.risk_level.value, rc.risk_level.value),
+            "explanation": rc.explanation,
+            "evidence_clause_ids": rc.evidence_clause_ids or [],
+            "evidence_text": rc.evidence_text,
+        }
+        for rc in (contract.risk_clauses or [])
+    ]
+
+    analysis = contract.analysis_result
+    template = _jinja_env.get_template("contract_report.html")
+    html = template.render(
+        original_filename=contract.original_filename,
+        contract_type=contract.contract_type.value,
+        analyzed_at=contract.analysis_completed_at or contract.updated_at,
+        generated_at=datetime.now(),
+        key_info=(analysis.key_info if analysis else None),
+        summary=(analysis.summary if analysis else None),
+        risk_clauses=risk_clauses,
+        clauses=[{"clause_id": c.clause_id, "title": c.title, "text": c.text, "order": c.order} for c in clauses],
+    )
+
+    pdf_bytes: bytes = HTML(string=html).write_pdf()
+    safe_name = (contract.original_filename or f"contract-{contract_id}").rsplit(".", 1)[0]
+    download_filename = f"{safe_name}_분석보고서.pdf"
+    return pdf_bytes, download_filename

--- a/app/services/share_service.py
+++ b/app/services/share_service.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.security import (
+    hash_password, verify_password,
+    create_share_access_token, decode_share_access_token,
+)
+from app.models.contract import Contract, ContractStatus
+from app.models.contract_share import ContractShare
+
+
+def _build_share_url(token: str) -> str:
+    return f"{settings.frontend_base_url.rstrip('/')}{settings.share_path}/{token}"
+
+
+def _to_aware_utc(dt: datetime) -> datetime:
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _ensure_owner_contract(contract_id: int, user_id: int, db: Session) -> Contract:
+    contract = db.query(Contract).filter(Contract.id == contract_id, Contract.user_id == user_id).first()
+    if not contract:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="계약서를 찾을 수 없습니다.")
+    return contract
+
+
+# ── 소유자 액션 ────────────────────────────────────────────────────────────
+
+def create_share(
+    contract_id: int, user_id: int, password: str, expire_days: Optional[int], db: Session
+) -> ContractShare:
+    """공유 링크 생성. 분석 완료된 계약서에만 가능."""
+    contract = _ensure_owner_contract(contract_id, user_id, db)
+    if contract.status != ContractStatus.COMPLETED:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="분석이 완료된 계약서만 공유할 수 있습니다.")
+
+    days = expire_days or settings.share_token_default_expire_days
+    expires_at = datetime.now(timezone.utc) + timedelta(days=days)
+    token = secrets.token_urlsafe(32)
+
+    share = ContractShare(
+        contract_id=contract_id,
+        token=token,
+        password_hash=hash_password(password),
+        expires_at=expires_at,
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def list_shares(contract_id: int, user_id: int, db: Session) -> list[ContractShare]:
+    _ensure_owner_contract(contract_id, user_id, db)
+    return (
+        db.query(ContractShare)
+        .filter(ContractShare.contract_id == contract_id)
+        .order_by(ContractShare.created_at.desc())
+        .all()
+    )
+
+
+def revoke_share(share_id: int, contract_id: int, user_id: int, db: Session) -> None:
+    _ensure_owner_contract(contract_id, user_id, db)
+    share = db.query(ContractShare).filter(
+        ContractShare.id == share_id, ContractShare.contract_id == contract_id
+    ).first()
+    if not share:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="공유 링크를 찾을 수 없습니다.")
+    if share.revoked_at is None:
+        share.revoked_at = datetime.now(timezone.utc)
+        db.commit()
+
+
+def is_share_active(share: ContractShare) -> bool:
+    if share.revoked_at is not None:
+        return False
+    return datetime.now(timezone.utc) <= _to_aware_utc(share.expires_at)
+
+
+# ── 공유받은 사람 액션 ─────────────────────────────────────────────────────
+
+def verify_share_password(token: str, password: str, db: Session) -> Tuple[str, datetime]:
+    """비밀번호 검증 후 임시 access token(JWT) 발급."""
+    share = db.query(ContractShare).filter(ContractShare.token == token).first()
+    if not share or not is_share_active(share):
+        # 토큰 존재 여부와 관계없이 동일한 메시지 — 토큰 추측 공격 방지
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="유효하지 않거나 만료된 공유 링크입니다.")
+    if not verify_password(password, share.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="비밀번호가 올바르지 않습니다.")
+
+    return create_share_access_token(token)
+
+
+def get_shared_contract(share_access_token: str, db: Session) -> Tuple[ContractShare, Contract]:
+    """share access token 검증 → 공유 행 + Contract 반환. 비로그인 진입 후 결과 조회용."""
+    token = decode_share_access_token(share_access_token)
+    share = db.query(ContractShare).filter(ContractShare.token == token).first()
+    if not share or not is_share_active(share):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="유효하지 않거나 만료된 공유 링크입니다.")
+    contract = db.query(Contract).filter(Contract.id == share.contract_id).first()
+    if not contract:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="계약서를 찾을 수 없습니다.")
+    return share, contract
+
+
+def share_to_response_dict(share: ContractShare) -> dict:
+    """ShareCreateResponse / ShareListItem 공통 변환 — share_url, is_active 부착."""
+    return {
+        "id": share.id,
+        "token": share.token,
+        "share_url": _build_share_url(share.token),
+        "expires_at": share.expires_at,
+        "revoked_at": share.revoked_at,
+        "created_at": share.created_at,
+        "is_active": is_share_active(share),
+    }

--- a/app/templates/pdf/contract_report.html
+++ b/app/templates/pdf/contract_report.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ original_filename }} - 분석 보고서</title>
+  <style>
+    @page {
+      size: A4;
+      margin: 22mm 18mm 22mm 18mm;
+      @bottom-center {
+        content: counter(page) " / " counter(pages);
+        font-size: 9pt;
+        color: #999;
+      }
+    }
+    body {
+      font-family: -apple-system, "Apple SD Gothic Neo", "Malgun Gothic", "맑은 고딕", "NanumGothic", "Helvetica Neue", Helvetica, sans-serif;
+      color: #1f2937;
+      font-size: 10.5pt;
+      line-height: 1.55;
+    }
+    h1 { font-size: 20pt; margin: 0 0 4px 0; color: #111827; }
+    h2 { font-size: 13pt; margin: 22px 0 10px 0; color: #111827; border-bottom: 2px solid #2563eb; padding-bottom: 4px; }
+    h3 { font-size: 11pt; margin: 14px 0 6px 0; color: #1f2937; }
+    .meta { color: #6b7280; font-size: 10pt; }
+    .header { margin-bottom: 18px; padding-bottom: 14px; border-bottom: 1px solid #e5e7eb; }
+    .label { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 9pt; font-weight: 600; }
+    .label-contract-type { background: #eff6ff; color: #1d4ed8; }
+
+    table.kv { width: 100%; border-collapse: collapse; margin: 8px 0; }
+    table.kv td { padding: 7px 10px; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    table.kv td.k { width: 30%; color: #6b7280; font-weight: 500; }
+    table.kv td.v { color: #111827; }
+
+    .summary-box { background: #f9fafb; border-left: 3px solid #2563eb; padding: 12px 14px; margin: 8px 0; border-radius: 0 6px 6px 0; }
+
+    .risk-card {
+      border: 1px solid #e5e7eb;
+      border-left-width: 4px;
+      border-radius: 6px;
+      padding: 10px 14px;
+      margin: 10px 0;
+      page-break-inside: avoid;
+    }
+    .risk-high   { border-left-color: #dc2626; background: #fef2f2; }
+    .risk-medium { border-left-color: #d97706; background: #fffbeb; }
+    .risk-low    { border-left-color: #059669; background: #ecfdf5; }
+    .risk-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 9pt;
+      font-weight: 600;
+      margin-right: 6px;
+    }
+    .badge-high   { background: #dc2626; color: white; }
+    .badge-medium { background: #d97706; color: white; }
+    .badge-low    { background: #059669; color: white; }
+    .risk-meta { color: #6b7280; font-size: 9.5pt; margin-bottom: 4px; }
+    .risk-explanation { margin: 6px 0; }
+    .evidence { background: rgba(255,255,255,0.7); border: 1px dashed #d1d5db; border-radius: 4px; padding: 8px 10px; margin-top: 6px; font-size: 9.5pt; color: #4b5563; }
+    .evidence .lbl { font-weight: 600; color: #6b7280; }
+
+    .clause {
+      page-break-inside: avoid;
+      margin: 10px 0 16px 0;
+      padding: 10px 12px;
+      background: #fafafa;
+      border-radius: 6px;
+    }
+    .clause .num { color: #2563eb; font-weight: 600; font-size: 9.5pt; }
+    .clause .title { font-weight: 600; margin: 2px 0 6px 0; }
+    .clause .text { white-space: pre-wrap; font-size: 10pt; color: #374151; }
+
+    .empty { color: #9ca3af; font-style: italic; padding: 6px 0; }
+  </style>
+</head>
+<body>
+
+  <div class="header">
+    <h1>{{ original_filename }}</h1>
+    <div class="meta">
+      <span class="label label-contract-type">{{ contract_type }}</span>
+      &nbsp;
+      분석일: {{ analyzed_at.strftime('%Y-%m-%d %H:%M') if analyzed_at else '-' }}
+      &nbsp;·&nbsp;
+      보고서 생성: {{ generated_at.strftime('%Y-%m-%d %H:%M') }}
+    </div>
+  </div>
+
+  {# ─── 1. 핵심 정보 ─────────────────────────────────────────────── #}
+  <h2>1. 핵심 정보</h2>
+  {% if key_info %}
+    <table class="kv">
+      {% for key, val in key_info.items() %}
+        <tr>
+          <td class="k">{{ key }}</td>
+          <td class="v">
+            {% if val is mapping %}
+              {{ val.get('value', '-') }}
+              {% if val.get('reason') %}<br><span class="meta">근거: {{ val.get('reason') }}</span>{% endif %}
+            {% else %}
+              {{ val if val is not none else '-' }}
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  {% else %}
+    <div class="empty">추출된 핵심 정보가 없습니다.</div>
+  {% endif %}
+
+  {# ─── 2. AI 요약 ──────────────────────────────────────────────── #}
+  <h2>2. AI 요약</h2>
+  {% if summary %}
+    <div class="summary-box">{{ summary }}</div>
+  {% else %}
+    <div class="empty">요약이 없습니다.</div>
+  {% endif %}
+
+  {# ─── 3. 위험 조항 ────────────────────────────────────────────── #}
+  <h2>3. 위험 조항 ({{ risk_clauses|length }}건)</h2>
+  {% if risk_clauses %}
+    {% for r in risk_clauses %}
+      <div class="risk-card risk-{{ r.risk_level }}">
+        <div class="risk-meta">
+          <span class="risk-badge badge-{{ r.risk_level }}">위험도 {{ r.risk_level_label }}</span>
+          <strong>{{ r.risk_type }}</strong>
+          {% if r.clause_number %}&nbsp;·&nbsp;{{ r.clause_number }}{% endif %}
+        </div>
+        {% if r.explanation %}
+          <div class="risk-explanation">{{ r.explanation }}</div>
+        {% endif %}
+        {% if r.evidence_text %}
+          <div class="evidence">
+            <span class="lbl">근거:</span> {{ r.evidence_text }}
+            {% if r.evidence_clause_ids %}
+              <br><span class="lbl">참조 조항:</span> {{ r.evidence_clause_ids|join(', ') }}
+            {% endif %}
+          </div>
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="empty">탐지된 위험 조항이 없습니다.</div>
+  {% endif %}
+
+  {# ─── 4. 조항 전문 ────────────────────────────────────────────── #}
+  <h2>4. 조항 전문 ({{ clauses|length }}개)</h2>
+  {% if clauses %}
+    {% for c in clauses %}
+      <div class="clause">
+        <div class="num">{{ c.clause_id }}</div>
+        {% if c.title %}<div class="title">{{ c.title }}</div>{% endif %}
+        <div class="text">{{ c.text }}</div>
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="empty">조항이 없습니다.</div>
+  {% endif %}
+
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
   "aiofiles>=24.0.0",
   "httpx>=0.27.0",
   "alembic>=1.13.0",
+  "weasyprint>=60.0",
+  "jinja2>=3.1.0",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ passlib[bcrypt]
 pydantic[email]
 aiofiles
 httpx
+weasyprint
+jinja2


### PR DESCRIPTION
## 관련 이슈
Closes #17

## 개요
계약서 분석 결과를 외부 사용자와 공유(토큰 링크 + 비밀번호) 또는 PDF 보고서로 다운로드할 수 있는 기능 추가.

## 변경 사항
- **DB 모델 (신규)**
  - \`ContractShare\` (\`contract_shares\` 테이블) — token, password_hash(bcrypt), expires_at, revoked_at
  - \`init_db.py\`에 신규 모델 import 추가
- **공유 서비스** (\`app/services/share_service.py\` 신규)
  - \`create_share\`, \`list_shares\`, \`revoke_share\`
  - \`verify_share_password\` — 비밀번호 검증 후 임시 JWT(share access token) 발급
  - \`get_shared_contract\` — JWT 검증 후 Contract 반환
- **PDF 서비스** (\`app/services/pdf_service.py\` 신규)
  - WeasyPrint + Jinja2로 한국어 분석 보고서 생성
  - macOS DYLD 경로 자동 설정 (SIP 환경 호환)
- **PDF 템플릿** (\`app/templates/pdf/contract_report.html\` 신규)
  - 기본 정보 + 핵심 정보 + AI 요약 + 위험 조항(위험도별 색상) + 조항 전문
- **공유 라우터** (\`app/api/v1/shares.py\` 신규) — 외부 비로그인 접근용
- **계약서 라우터 확장** (\`app/api/v1/contracts.py\`) — 공유/PDF 4개 엔드포인트 추가
- **JWT 헬퍼** (\`app/core/security.py\`) — \`create_share_access_token\`, \`decode_share_access_token\`
- **스키마** (\`app/schemas/share.py\` 신규)
- **설정** (\`app/core/config.py\`) — share 관련 4개 항목, \`extra=\"ignore\"\` 추가 (브랜치별 env 호환)
- **의존성** — \`weasyprint\`, \`jinja2\` 추가

## API 엔드포인트
**소유자 (인증)**
| Method | Path | 설명 |
|---|---|---|
| POST | \`/api/v1/contracts/{id}/share\` | 공유 링크 생성 (body: password, expire_days?) |
| GET  | \`/api/v1/contracts/{id}/shares\` | 본인 공유 링크 목록 |
| DELETE | \`/api/v1/contracts/{id}/shares/{share_id}\` | 공유 해제 (revoke) |
| GET | \`/api/v1/contracts/{id}/download/pdf\` | PDF 다운로드 |

**외부 (비로그인)**
| Method | Path | 설명 |
|---|---|---|
| POST | \`/api/v1/shares/{token}/verify\` | 비밀번호 검증 → access_token 발급 |
| GET | \`/api/v1/shares/{token}\` | Bearer access_token으로 결과 조회 |

## 보안 고려사항
- 비밀번호: **bcrypt 해시 저장** (평문 저장 X, 검증은 \`verify_password\`)
- 토큰: \`secrets.token_urlsafe(32)\` — URL-safe 32바이트 무작위
- 공유 access token: 짧은 만료(60분)의 별도 JWT (\`type: \"share\"\`)
- 토큰 추측 공격 방지: 존재하지 않는 토큰 / 만료 / revoked 모두 동일 메시지 반환
- 공유받은 사람은 **보기 전용** — PDF 다운로드 차단, OCR 원문 / 조항 전문 미노출

## 사양
- 만료 기본값 **7일** (1~30일 선택 가능)
- 비밀번호 **4자 이상** 필수
- 노출 범위: **분석 결과 + 위험 조항 + 근거**

## 테스트 방법
- [x] 더미 데이터로 PDF 렌더링 검증 (\`/tmp/sample_분석보고서.pdf\` 73KB 생성 OK)
- [ ] \`POST /share\`로 공유 링크 생성 → 응답에 token / share_url / expires_at 확인
- [ ] 다른 브라우저(시크릿)에서 share_url 접근 → 비밀번호 입력 → 결과 표시 확인
- [ ] 비밀번호 틀린 경우 401, 잘못된 토큰의 경우 404 확인
- [ ] \`DELETE /shares/{share_id}\` 후 같은 링크 재접근 시 404 확인
- [ ] 만료일 경과 후 404 확인
- [ ] \`GET /download/pdf\` → PDF 파일 다운로드 정상 (한글 파일명 포함)

## 환경변수 추가 (.env)
\`\`\`
FRONTEND_BASE_URL=http://localhost:5173
SHARE_PATH=/share
SHARE_TOKEN_DEFAULT_EXPIRE_DAYS=7
SHARE_ACCESS_TOKEN_EXPIRE_MINUTES=60
\`\`\`

## 시스템 의존성
WeasyPrint은 pango/glib 등 시스템 라이브러리 필요.
- macOS: \`brew install pango\`
- Ubuntu: \`apt install libpango-1.0-0 libpangoft2-1.0-0\`

## DB 스키마 변경
- \`contract_shares\` 테이블 자동 생성 (\`init_db()\`)
- 마이그레이션은 Alembic 미사용으로 \`Base.metadata.create_all()\`이 처리

## 프론트엔드 작업 안내
- \`/share/{token}\` 페이지 신규: 비밀번호 입력 → \`POST /verify\` → access_token으로 \`GET /shares/{token}\` 호출
- 본인 계약서 상세에 "공유 링크 만들기" 모달 + "PDF 다운로드" 버튼 추가