### PR TITLE
fix: AI_SERVICE_URL localhost → 127.0.0.1 및 .env.example 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,11 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # === clair-ai 마이크로서비스 (분석/채팅 테스트 시만 필요) ===
 # clair-ai 서버를 따로 띄워야 동작 (포트 8001). 백엔드만 테스트할 거면 그대로 두세요.
-AI_SERVICE_URL=http://localhost:8001
-AI_SERVICE_TIMEOUT=120
+#
+# ⚠️  macOS 주의: localhost가 IPv6(::1)로 resolve되어 uvicorn(IPv4)에 연결 실패할 수 있음
+#     반드시 127.0.0.1 을 사용할 것
+AI_SERVICE_URL=http://127.0.0.1:8001
+AI_SERVICE_TIMEOUT=300.0
 GEMINI_API_KEY=
 
 


### PR DESCRIPTION
## Summary

Closes #20

macOS 환경에서 `localhost`가 IPv6로 resolve되어 clair-ai에 연결되지 않던 문제를 문서화하고 `.env.example`에 올바른 설정값 명시.

## 변경 내용

- `.env.example` 신규 추가
  - `AI_SERVICE_URL=http://127.0.0.1:8001` (localhost 대신 명시적 IPv4 사용)
  - 주의사항 주석 포함

## 배경

`AI_SERVICE_URL=http://localhost:8001` 설정 시 분석 요청이 clair-ai에 전달되지 않아 status가 `processing`에서 멈추는 문제가 있었음. Python의 `getaddrinfo`가 localhost를 IPv6(`::1`)로 먼저 resolve하는데 uvicorn이 IPv4만 바인딩하기 때문.

## Test plan

- [x] `.env`에 `AI_SERVICE_URL=http://127.0.0.1:8001` 설정 후 분석 요청 → `completed` 정상 전환 확인