### PR TITLE
feat: 이미지 여러 장을 한 계약서로 업로드하는 엔드포인트 추가

### DIFF
--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -15,7 +15,8 @@ from app.schemas.share import (
     ShareListItem, ShareListResponse,
 )
 from app.services.contract_service import (
-    upload_contract, get_contract_by_id, get_contracts_by_user, delete_contract,
+    upload_contract, upload_contract_from_images,
+    get_contract_by_id, get_contracts_by_user, delete_contract,
     trigger_analysis, analyze_contract_background, get_clauses,
 )
 from app.services.share_service import (
@@ -31,6 +32,28 @@ async def api_upload_contract(file: UploadFile = File(...), user: User = Depends
     contract = await upload_contract(file=file, user_id=user.id, db=db)
     return ContractUploadResponse(id=contract.id, original_filename=contract.original_filename, file_size=contract.file_size,
                                   file_type=contract.file_type, status=contract.status.value, created_at=contract.created_at)
+
+
+@router.post(
+    "/upload-images",
+    response_model=ContractUploadResponse,
+    status_code=201,
+    summary="이미지 여러 장을 한 계약서로 업로드 (폰 스캐너 방식)",
+)
+async def api_upload_contract_images(
+    files: list[UploadFile] = File(..., description="순서대로 업로드된 페이지 이미지들 (PNG/JPG/JPEG, 최대 20장)"),
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    contract = await upload_contract_from_images(files=files, user_id=user.id, db=db)
+    return ContractUploadResponse(
+        id=contract.id,
+        original_filename=contract.original_filename,
+        file_size=contract.file_size,
+        file_type=contract.file_type,
+        status=contract.status.value,
+        created_at=contract.created_at,
+    )
 
 
 @router.get("/", response_model=ContractListResponse, summary="계약서 목록 조회")

--- a/app/services/contract_service.py
+++ b/app/services/contract_service.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import os
 import uuid
 from datetime import datetime, timezone
+from io import BytesIO
 from pathlib import Path
+from PIL import Image, ImageOps
 from fastapi import UploadFile, HTTPException, status
 from sqlalchemy.orm import Session
 from app.core.config import settings
@@ -69,6 +71,117 @@ async def upload_contract(file: UploadFile, user_id: int, db: Session) -> Contra
     contract = Contract(user_id=user_id, original_filename=file.filename, stored_filename=stored_filename,
                         file_path=str(file_path), file_size=file_size, file_type=file_ext,
                         mime_type=_get_mime_type(file.filename), status=ContractStatus.UPLOADED)
+    db.add(contract)
+    db.commit()
+    db.refresh(contract)
+    return contract
+
+
+# ── 다중 이미지 업로드 (폰 스캐너 방식) ────────────────────────────────────────
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
+_MAX_IMAGES_PER_CONTRACT = 20
+
+
+async def _merge_images_to_pdf(files: list[UploadFile]) -> tuple[bytes, int]:
+    """업로드된 이미지들을 순서대로 한 PDF로 합쳐 (pdf_bytes, raw_total_size) 반환.
+
+    raw_total_size: 변환 전 원본 이미지 총 바이트(한도 검사에 사용).
+    EXIF orientation은 ImageOps.exif_transpose로 자동 보정 — 폰 사진 회전 깨짐 방지.
+    """
+    images: list[Image.Image] = []
+    raw_total_size = 0
+    for f in files:
+        content = await f.read()
+        if not content:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"빈 파일이 포함되어 있습니다: {f.filename}",
+            )
+        raw_total_size += len(content)
+        try:
+            img = Image.open(BytesIO(content))
+            img = ImageOps.exif_transpose(img).convert("RGB")
+        except Exception as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"이미지를 읽을 수 없습니다 ({f.filename}): {e}",
+            )
+        images.append(img)
+
+    buf = BytesIO()
+    images[0].save(buf, format="PDF", save_all=True, append_images=images[1:])
+    return buf.getvalue(), raw_total_size
+
+
+async def upload_contract_from_images(
+    files: list[UploadFile], user_id: int, db: Session
+) -> Contract:
+    """이미지 여러 장을 받아 한 PDF로 병합 후 단일 Contract로 저장.
+
+    - 폰으로 페이지별로 찍은 사진들을 한 계약서로 묶어 업로드하는 용도
+    - AI 분석 파이프라인은 PDF 다중 페이지를 이미 지원하므로 별도 수정 불필요
+    """
+    if not files:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="이미지를 1장 이상 업로드해주세요.")
+    if len(files) > _MAX_IMAGES_PER_CONTRACT:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"한 번에 최대 {_MAX_IMAGES_PER_CONTRACT}장까지 업로드할 수 있습니다.",
+        )
+    for f in files:
+        if not f.filename:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="파일명이 없는 항목이 있습니다.")
+        ext = Path(f.filename).suffix.lower()
+        if ext not in _IMAGE_EXTENSIONS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"지원하지 않는 이미지 형식입니다 ({f.filename}): PNG/JPG/JPEG만 가능",
+            )
+
+    pdf_bytes, raw_total_size = await _merge_images_to_pdf(files)
+
+    # 한도 검사 — 원본 합계와 병합 PDF 둘 다 max_file_size 이하여야 함
+    if raw_total_size > settings.max_file_size_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"전체 이미지 크기 합이 {settings.max_file_size_mb}MB를 초과합니다.",
+        )
+    if len(pdf_bytes) > settings.max_file_size_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"병합된 PDF 크기가 {settings.max_file_size_mb}MB를 초과합니다.",
+        )
+
+    # 저장 경로 규칙은 단일 업로드와 동일 (YYYY/MM/DD/{uuid}.pdf)
+    upload_dir = Path(settings.upload_dir)
+    today = datetime.now()
+    date_dir = upload_dir / today.strftime("%Y") / today.strftime("%m") / today.strftime("%d")
+    date_dir.mkdir(parents=True, exist_ok=True)
+    stored_filename = f"{uuid.uuid4().hex}.pdf"
+    file_path = date_dir / stored_filename
+
+    try:
+        file_path.write_bytes(pdf_bytes)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"파일 저장 중 오류: {e}",
+        )
+
+    first_name = files[0].filename
+    display_name = f"{first_name} 외 {len(files) - 1}장" if len(files) > 1 else first_name
+
+    contract = Contract(
+        user_id=user_id,
+        original_filename=display_name,
+        stored_filename=stored_filename,
+        file_path=str(file_path),
+        file_size=len(pdf_bytes),
+        file_type=".pdf",                # AI 파이프라인은 PDF로 인식하여 페이지별 OCR 수행
+        mime_type="application/pdf",
+        status=ContractStatus.UPLOADED,
+    )
     db.add(contract)
     db.commit()
     db.refresh(contract)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ httpx
 fastapi-mail==1.4.1
 weasyprint
 jinja2
+Pillow


### PR DESCRIPTION
Closes #23

## Summary
- 폰으로 페이지별로 찍은 사진들을 한 계약서로 묶어 업로드하는 새 엔드포인트 추가
- `POST /api/v1/contracts/upload-images`: 이미지 N장 → 한 PDF로 병합 → 단일 Contract 저장
- AI 분석 파이프라인은 이미 멀티페이지 PDF 지원 → 백엔드 추가 변경 0줄, 그대로 동작
- 기존 `POST /upload`(단일 PDF/이미지/텍스트) 엔드포인트는 무변경

## 동작 흐름
\`\`\`
프론트가 multipart로 이미지 N장 전송 (필드명: files)
       ↓
POST /api/v1/contracts/upload-images
       ↓
Pillow로 한 PDF에 페이지 순서대로 병합
       ├─ EXIF orientation 자동 보정 (폰 사진 회전 깨짐 방지)
       └─ RGB → 멀티페이지 PDF
       ↓
UPLOAD_DIR/YYYY/MM/DD/{uuid}.pdf 저장
       ↓
Contract 행 1개 생성 (file_type=\".pdf\", mime=\"application/pdf\")
       ↓
201 + contract_id 반환
\`\`\`

## 보호 장치
- 최대 **20장** 제한
- **PNG/JPG/JPEG** 만 허용
- 빈 파일 거부
- **원본 합계 + 병합 PDF 둘 다** \`MAX_FILE_SIZE_MB\` 검사 (변환 후 크기 증가 케이스 방지)
- \`original_filename\`은 \"page1.jpg 외 N장\" 형식

## 페이지 순서
백엔드는 multipart 폼 필드 순서를 그대로 페이지 순서로 사용합니다. 즉 **프론트가 순서를 책임지는 구조** — \`Upload.tsx\`에 재정렬 UI(드래그앤드롭/↑↓ 버튼)를 붙이는 게 다음 작업.

## 변경 파일
- \`requirements.txt\`: \`Pillow\` 명시 (weasyprint 통해 이미 설치돼 있던 것을 first-class dep으로)
- \`app/services/contract_service.py\`: \`_merge_images_to_pdf()\`, \`upload_contract_from_images()\` 추가
- \`app/api/v1/contracts.py\`: \`POST /upload-images\` 엔드포인트 추가

## Test plan
- [ ] Swagger UI(\`/docs\`)에서 이미지 2~3장 업로드 → 201 + contract_id 응답 확인
- [ ] 저장된 PDF를 직접 열어 페이지 순서가 업로드 순서와 일치하는지 확인
- [ ] 폰 가로/세로 사진 섞어서 업로드 → EXIF 보정으로 모두 정방향으로 들어가는지 확인
- [ ] 20장 초과 / 비이미지 파일 / 빈 파일 → 400 응답 확인
- [ ] 큰 이미지 묶음 업로드 → 413 응답 확인
- [ ] 업로드된 contract로 \`/analyze\` 호출 → 페이지별 OCR이 정상 수행되는지 확인