### PR TITLE
chore+fix: DB 마이그레이션 + contract_type 매퍼 한글 매핑 추가

### DIFF
--- a/app/integrations/mappers.py
+++ b/app/integrations/mappers.py
@@ -11,12 +11,22 @@ from app.models.contract import ContractType
 from app.models.analysis import AnalysisResult, RiskClause, ContractClause, RiskLevel, ComplianceResult
 
 # clair-ai가 반환하는 contract_type 문자열 → ContractType Enum 변환 테이블
-# AI 출력값이 추가될 경우 여기에만 추가하면 됨
+# AI 출력값이 추가될 경우 여기에만 추가하면 됨.
+# 프롬프트가 영문/한글을 섞어 반환하는 경우가 있어 양쪽 모두 등록한다.
 _AI_TYPE_MAP: dict[str, ContractType] = {
+    # 영문 (AI가 enum-style로 반환하는 케이스)
     "nda": ContractType.NDA,
     "service": ContractType.SERVICE,
     "employment": ContractType.EMPLOYMENT,
     "unknown": ContractType.UNKNOWN,
+    # 한글 (AI가 한국어 라벨로 반환하는 케이스 — 근로계약서 분석 시 관찰됨)
+    "근로계약": ContractType.EMPLOYMENT,
+    "근로계약서": ContractType.EMPLOYMENT,
+    "비밀유지계약": ContractType.NDA,
+    "비밀유지계약서": ContractType.NDA,
+    "비밀유지서약서": ContractType.NDA,
+    "용역계약": ContractType.SERVICE,
+    "용역계약서": ContractType.SERVICE,
 }
 
 # AI severity 문자열 → RiskLevel Enum 변환 테이블

--- a/scripts/migrate_2026_05_dev_sync.sql
+++ b/scripts/migrate_2026_05_dev_sync.sql
@@ -1,0 +1,63 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- dev 브랜치 동기화 마이그레이션 (2026-05)
+--
+-- 대상: 예전 코드로 init_db()를 돌려 contracts/analysis_results/risk_clauses가
+--       이미 만들어진 로컬 MySQL.
+--
+-- 왜 필요한가:
+--   init_db()는 create_all()만 호출 — 기존 테이블의 컬럼/ENUM은 자동으로 안 바뀜.
+--   dev에 머지된 모델 변경(분석 파이프라인 + 법령 준수 검사 + clause_id 매핑)이
+--   기존 DB에 반영되지 않아 분석 시 "Unknown column" / "Data truncated" 에러 발생.
+--
+-- 실행:
+--   mysql -u root -p clair_db < scripts/migrate_2026_05_dev_sync.sql
+--
+-- 멱등성:
+--   ADD COLUMN은 INFORMATION_SCHEMA로 존재 여부 확인 후 실행 — 여러 번 돌려도 안전.
+--   MODIFY COLUMN(ENUM 확장)은 같은 정의로 덮어쓰는 거라 자연히 멱등.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ── 1. contracts.status ENUM에 PENDING 추가 ─────────────────────────────────
+ALTER TABLE contracts MODIFY COLUMN status
+  ENUM('UPLOADED','PENDING','PROCESSING','COMPLETED','FAILED')
+  NOT NULL DEFAULT 'UPLOADED';
+
+-- ── 2. contracts.contract_type ENUM에 NDA/SERVICE/EMPLOYMENT 추가 ────────────
+ALTER TABLE contracts MODIFY COLUMN contract_type
+  ENUM('LABOR','COMPANY_RULE','FREELANCE','NDA','SERVICE','EMPLOYMENT','OTHER','UNKNOWN');
+
+-- ── 3. analysis_results에 누락된 컬럼 추가 ─────────────────────────────────
+-- raw_ocr_text: OCR 원문 (디버깅/재분석용)
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'analysis_results' AND COLUMN_NAME = 'raw_ocr_text');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE analysis_results ADD COLUMN raw_ocr_text TEXT NULL',
+  'SELECT ''analysis_results.raw_ocr_text already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- analysis_duration_seconds: 분석 소요 시간 (성능 모니터링)
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'analysis_results' AND COLUMN_NAME = 'analysis_duration_seconds');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE analysis_results ADD COLUMN analysis_duration_seconds INT NULL',
+  'SELECT ''analysis_results.analysis_duration_seconds already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── 4. risk_clauses에 누락된 컬럼 추가 ─────────────────────────────────────
+-- evidence_clause_ids: 위험 조항의 근거 clause_id 목록 (프론트 하이라이트용)
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'risk_clauses' AND COLUMN_NAME = 'evidence_clause_ids');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE risk_clauses ADD COLUMN evidence_clause_ids JSON NULL',
+  'SELECT ''risk_clauses.evidence_clause_ids already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- evidence_text: AI가 추출한 근거 원문 발췌
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'risk_clauses' AND COLUMN_NAME = 'evidence_text');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE risk_clauses ADD COLUMN evidence_text TEXT NULL',
+  'SELECT ''risk_clauses.evidence_text already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT '마이그레이션 완료' AS result;


### PR DESCRIPTION
Closes #24
Closes #26

## Summary

이 PR은 두 가지 변경을 묶고 있습니다.

### 1. DB 마이그레이션 스크립트 추가 (#24)
- `scripts/migrate_2026_05_dev_sync.sql` — dev에 머지된 모델 변경(status/contract_type ENUM 확장, analysis_results/risk_clauses 신규 컬럼)을 기존 로컬 DB에 반영
- `INFORMATION_SCHEMA` 체크로 멱등성 보장 — 여러 번 돌려도 안전

### 2. contract_type 매퍼 한글 매핑 추가 (#26)
- `app/integrations/mappers.py` — `_AI_TYPE_MAP`에 `"근로계약"`, `"비밀유지서약서"`, `"용역계약서"` 등 한글 키 추가
- AI가 영문/한글을 섞어 반환하던 문제 해결 — 한글 반환값이 모두 UNKNOWN으로 떨어지지 않게 함

## Why

`init_db()`는 `create_all()`만 호출 → 기존 테이블의 컬럼/ENUM은 자동 변경 안 됨. 예전에 한 번이라도 서버 돌린 팀원은 분석 시 `Data truncated for column 'status'` / `Unknown column 'raw_ocr_text'` 에러로 깨짐.

마이그레이션 후 실제 분석을 돌려보니 근로계약서가 DB에 `unknown`으로 저장되는 추가 버그를 발견. 같은 분석 검증 흐름에서 잡힌 거라 함께 묶었음.

## 팀원 실행 가이드

```bash
git pull origin dev
mysql -u root -p clair_db < scripts/migrate_2026_05_dev_sync.sql
```

멱등성이라 여러 번 돌려도 안전. 새로 세팅하는 사람은 안 돌려도 됨.

## Test plan
- [x] 변경된 컬럼이 이미 있는 DB에서 마이그레이션 재실행 → 모두 `skip_reason` 으로 스킵, 에러 없음 확인
- [x] 비밀유지서약서.pdf 분석: completed, contract_type=nda (영문 매핑 정상)
- [x] 근로계약서.pdf 분석: completed, key_info.contract_type="근로계약"
- [x] 매퍼 유닛 테스트: 영문/한글/대소문자 케이스 7건 모두 통과
- [ ] 팀원 1명 이상이 자기 로컬에서 마이그레이션 실행해서 문제없는지 확인

## 후속 작업

- clair-ai 프롬프트가 항상 영문 enum 값을 반환하도록 강제하는 것이 근본 해결. AI 팀에 별도 요청 필요 (clair-ai 레포 이슈)
- `/analyze` 응답에서 risks/compliance가 빈 결과로 떨어지는 별도 silent fail 이슈도 발견 — clair-ai 측이라 별도 처리