### PR TITLE
fix: 채팅 세션 목록에 메타데이터 추가

### DIFF
--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -1,41 +1,91 @@
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.core.security import get_current_user
 from app.models.user import User
-from app.schemas.chat import ChatSessionCreateRequest, ChatSessionResponse, ChatSessionListResponse, SendMessageRequest, SendMessageResponse, ChatMessageResponse, ChatMessagesListResponse
+from app.models.chat import ChatMessage, MessageSender
+from app.schemas.chat import ChatSessionCreateRequest, ChatSessionResponse, ChatSessionListItem, ChatSessionListResponse, SendMessageRequest, SendMessageResponse, ChatMessageResponse, ChatMessagesListResponse
 from app.schemas.contract import MessageResponse
 from app.services.chat_service import create_session, get_session_by_id, get_sessions_by_user, get_messages, send_message, delete_session
 
 router = APIRouter()
 
 
+def _session_to_response_dict(session) -> dict:
+    return {
+        "id": session.id,
+        "contract_id": session.contract_id,
+        "title": session.title,
+        "total_message_count": session.total_message_count or 0,
+        "last_message_at": session.last_message_at,
+        "created_at": session.created_at,
+        "updated_at": session.updated_at,
+    }
+
+
+def _fetch_message_extreme(db: Session, session_ids: list[int], sender: MessageSender, *, latest: bool) -> dict[int, str]:
+    """
+    세션 ID 리스트 → {session_id: 메시지 content}.
+    latest=True면 가장 최근, False면 가장 오래된 메시지를 sender 기준으로 1건씩 가져옴.
+    서브쿼리로 (session_id, MIN/MAX(created_at))을 묶고 본 테이블에 JOIN — 쿼리 1회.
+    """
+    if not session_ids:
+        return {}
+    agg = func.max(ChatMessage.created_at) if latest else func.min(ChatMessage.created_at)
+    sub = (
+        db.query(
+            ChatMessage.session_id.label("sid"),
+            agg.label("ts"),
+        )
+        .filter(
+            ChatMessage.session_id.in_(session_ids),
+            ChatMessage.sender == sender,
+        )
+        .group_by(ChatMessage.session_id)
+        .subquery()
+    )
+    rows = (
+        db.query(ChatMessage)
+        .join(sub, and_(ChatMessage.session_id == sub.c.sid, ChatMessage.created_at == sub.c.ts))
+        .all()
+    )
+    return {m.session_id: m.content for m in rows}
+
+
 @router.post("/sessions", status_code=201, summary="채팅 세션 생성")
 def api_create_session(body: ChatSessionCreateRequest, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     session = create_session(user_id=user.id, db=db, contract_id=body.contract_id, title=body.title or "새 대화")
-    return ChatSessionResponse(id=session.id, contract_id=session.contract_id, title=session.title,
-                               created_at=session.created_at, updated_at=session.updated_at)
+    return ChatSessionResponse(**_session_to_response_dict(session))
 
 
 @router.get("/sessions", response_model=ChatSessionListResponse, summary="채팅 세션 목록 (이력)")
 def api_list_sessions(skip: int = Query(0, ge=0), limit: int = Query(20, ge=1, le=100),
                       user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     total, sessions = get_sessions_by_user(user.id, db, skip, limit)
-    session_list = []
-    for s in sessions:
-        last_msg = None
-        if s.messages:
-            last_msg = s.messages[-1].content[:50] + "..." if len(s.messages[-1].content) > 50 else s.messages[-1].content
-        session_list.append(ChatSessionResponse(id=s.id, contract_id=s.contract_id, title=s.title,
-                                                created_at=s.created_at, updated_at=s.updated_at, last_message=last_msg))
-    return ChatSessionListResponse(total=total, sessions=session_list)
+    session_ids = [s.id for s in sessions]
+
+    # 페이지에 담긴 세션들의 첫 user 질문 / 마지막 user 질문 / 마지막 ai 응답을 각각 1쿼리로
+    first_q = _fetch_message_extreme(db, session_ids, MessageSender.USER, latest=False)
+    last_q = _fetch_message_extreme(db, session_ids, MessageSender.USER, latest=True)
+    last_a = _fetch_message_extreme(db, session_ids, MessageSender.AI, latest=True)
+
+    items = [
+        ChatSessionListItem(
+            **_session_to_response_dict(s),
+            first_question=first_q.get(s.id),
+            last_question=last_q.get(s.id),
+            last_answer=last_a.get(s.id),
+        )
+        for s in sessions
+    ]
+    return ChatSessionListResponse(total=total, sessions=items)
 
 
 @router.get("/sessions/{session_id}", response_model=ChatSessionResponse, summary="채팅 세션 상세")
 def api_get_session(session_id: int, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     session = get_session_by_id(session_id, user.id, db)
-    return ChatSessionResponse(id=session.id, contract_id=session.contract_id, title=session.title,
-                               created_at=session.created_at, updated_at=session.updated_at)
+    return ChatSessionResponse(**_session_to_response_dict(session))
 
 
 @router.delete("/sessions/{session_id}", response_model=MessageResponse, summary="채팅 세션 삭제")

--- a/app/integrations/mappers.py
+++ b/app/integrations/mappers.py
@@ -11,12 +11,22 @@ from app.models.contract import ContractType
 from app.models.analysis import AnalysisResult, RiskClause, ContractClause, RiskLevel, ComplianceResult
 
 # clair-ai가 반환하는 contract_type 문자열 → ContractType Enum 변환 테이블
-# AI 출력값이 추가될 경우 여기에만 추가하면 됨
+# AI 출력값이 추가될 경우 여기에만 추가하면 됨.
+# 프롬프트가 영문/한글을 섞어 반환하는 경우가 있어 양쪽 모두 등록한다.
 _AI_TYPE_MAP: dict[str, ContractType] = {
+    # 영문 (AI가 enum-style로 반환하는 케이스)
     "nda": ContractType.NDA,
     "service": ContractType.SERVICE,
     "employment": ContractType.EMPLOYMENT,
     "unknown": ContractType.UNKNOWN,
+    # 한글 (AI가 한국어 라벨로 반환하는 케이스 — 근로계약서 분석 시 관찰됨)
+    "근로계약": ContractType.EMPLOYMENT,
+    "근로계약서": ContractType.EMPLOYMENT,
+    "비밀유지계약": ContractType.NDA,
+    "비밀유지계약서": ContractType.NDA,
+    "비밀유지서약서": ContractType.NDA,
+    "용역계약": ContractType.SERVICE,
+    "용역계약서": ContractType.SERVICE,
 }
 
 # AI severity 문자열 → RiskLevel Enum 변환 테이블

--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -24,6 +24,9 @@ class ChatSession(Base):
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     contract_id = Column(Integer, ForeignKey("contracts.id", ondelete="SET NULL"), nullable=True, index=True)
     title = Column(String(200), nullable=False, default="새 대화")
+    # 세션 목록 조회 시 N+1 방지용 — 메시지 추가/삭제 시 chat_service에서 직접 갱신
+    total_message_count = Column(Integer, nullable=False, default=0, server_default="0")
+    last_message_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, server_default=func.now())
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
 

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -12,15 +12,23 @@ class ChatSessionResponse(BaseModel):
     id: int
     contract_id: Optional[int] = None
     title: str
+    total_message_count: int = 0
+    last_message_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
-    last_message: Optional[str] = None
     model_config = {"from_attributes": True}
+
+
+class ChatSessionListItem(ChatSessionResponse):
+    # 목록 화면에서만 채워지는 메타데이터 — 미리보기 카드용
+    first_question: Optional[str] = None    # 사용자가 처음 보낸 질문
+    last_question: Optional[str] = None     # 사용자가 마지막으로 보낸 질문
+    last_answer: Optional[str] = None       # AI 마지막 응답
 
 
 class ChatSessionListResponse(BaseModel):
     total: int
-    sessions: List[ChatSessionResponse]
+    sessions: List[ChatSessionListItem]
 
 
 class SendMessageRequest(BaseModel):

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -5,6 +6,11 @@ from app.models.chat import ChatSession, ChatMessage, MessageSender, MessageType
 from app.models.contract import Contract, ContractStatus
 from app.models.analysis import ContractClause
 from app.integrations.ai_client import ai_client
+
+
+def _bump_session_counters(session: ChatSession, delta: int, at: datetime) -> None:
+    session.total_message_count = (session.total_message_count or 0) + delta
+    session.last_message_at = at
 
 
 def create_session(user_id: int, db: Session, contract_id: int = None, title: str = "새 대화") -> ChatSession:
@@ -20,6 +26,7 @@ def create_session(user_id: int, db: Session, contract_id: int = None, title: st
     db.refresh(session)
     welcome = ChatMessage(session_id=session.id, sender=MessageSender.SYSTEM, message_type=MessageType.TEXT, content="계약서를 업로드하거나 질문을 입력해주세요.")
     db.add(welcome)
+    _bump_session_counters(session, delta=1, at=datetime.now(timezone.utc))
     db.commit()
     return session
 
@@ -57,6 +64,7 @@ async def send_message(session_id: int, user_id: int, content: str, message_type
         content=content,
     )
     db.add(user_msg)
+    _bump_session_counters(session, delta=1, at=datetime.now(timezone.utc))
     db.commit()
     db.refresh(user_msg)
 
@@ -83,7 +91,7 @@ async def send_message(session_id: int, user_id: int, content: str, message_type
         extra_data=ai_extra,    # evidence_clause_ids, evidence_clauses 포함
     )
     db.add(ai_msg)
-    session.updated_at = func.now()
+    _bump_session_counters(session, delta=1, at=datetime.now(timezone.utc))
     db.commit()
     db.refresh(ai_msg)
     return user_msg, ai_msg

--- a/scripts/migrate_2026_05_chat_session_meta.sql
+++ b/scripts/migrate_2026_05_chat_session_meta.sql
@@ -1,0 +1,48 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- chat_sessions 메타데이터 컬럼 추가 (2026-05)
+--
+-- 추가 내역:
+--   total_message_count INT NOT NULL DEFAULT 0  — 세션의 메시지 총 개수
+--   last_message_at     DATETIME NULL           — 마지막 메시지 시각
+--
+-- 왜:
+--   세션 목록 화면에서 "메시지 N개 / 마지막 대화 N분 전" 같은 정보를 보여줘야 하는데,
+--   매번 chat_messages를 COUNT/MAX 하면 세션 수가 늘수록 느려진다. 컬럼으로 캐싱.
+--
+-- 실행:
+--   mysql -u root -p clair_db < scripts/migrate_2026_05_chat_session_meta.sql
+--
+-- 멱등성:
+--   ADD COLUMN은 INFORMATION_SCHEMA로 존재 확인 후 실행 — 여러 번 돌려도 안전.
+--   백필 UPDATE도 멱등 (chat_messages 현재 상태 기준으로 다시 채움).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ── 1. total_message_count 추가 ─────────────────────────────────────────────
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'chat_sessions' AND COLUMN_NAME = 'total_message_count');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE chat_sessions ADD COLUMN total_message_count INT NOT NULL DEFAULT 0',
+  'SELECT ''chat_sessions.total_message_count already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── 2. last_message_at 추가 ────────────────────────────────────────────────
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'chat_sessions' AND COLUMN_NAME = 'last_message_at');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE chat_sessions ADD COLUMN last_message_at DATETIME NULL',
+  'SELECT ''chat_sessions.last_message_at already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── 3. 기존 세션 백필 ──────────────────────────────────────────────────────
+-- 모든 세션의 카운터/시각을 chat_messages 기준으로 다시 계산 — 멱등.
+UPDATE chat_sessions s
+LEFT JOIN (
+  SELECT session_id, COUNT(*) AS cnt, MAX(created_at) AS last_at
+  FROM chat_messages
+  GROUP BY session_id
+) m ON m.session_id = s.id
+SET
+  s.total_message_count = COALESCE(m.cnt, 0),
+  s.last_message_at     = m.last_at;
+
+SELECT 'chat_sessions 메타데이터 마이그레이션 완료' AS result;

--- a/scripts/migrate_2026_05_dev_sync.sql
+++ b/scripts/migrate_2026_05_dev_sync.sql
@@ -1,0 +1,63 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- dev 브랜치 동기화 마이그레이션 (2026-05)
+--
+-- 대상: 예전 코드로 init_db()를 돌려 contracts/analysis_results/risk_clauses가
+--       이미 만들어진 로컬 MySQL.
+--
+-- 왜 필요한가:
+--   init_db()는 create_all()만 호출 — 기존 테이블의 컬럼/ENUM은 자동으로 안 바뀜.
+--   dev에 머지된 모델 변경(분석 파이프라인 + 법령 준수 검사 + clause_id 매핑)이
+--   기존 DB에 반영되지 않아 분석 시 "Unknown column" / "Data truncated" 에러 발생.
+--
+-- 실행:
+--   mysql -u root -p clair_db < scripts/migrate_2026_05_dev_sync.sql
+--
+-- 멱등성:
+--   ADD COLUMN은 INFORMATION_SCHEMA로 존재 여부 확인 후 실행 — 여러 번 돌려도 안전.
+--   MODIFY COLUMN(ENUM 확장)은 같은 정의로 덮어쓰는 거라 자연히 멱등.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ── 1. contracts.status ENUM에 PENDING 추가 ─────────────────────────────────
+ALTER TABLE contracts MODIFY COLUMN status
+  ENUM('UPLOADED','PENDING','PROCESSING','COMPLETED','FAILED')
+  NOT NULL DEFAULT 'UPLOADED';
+
+-- ── 2. contracts.contract_type ENUM에 NDA/SERVICE/EMPLOYMENT 추가 ────────────
+ALTER TABLE contracts MODIFY COLUMN contract_type
+  ENUM('LABOR','COMPANY_RULE','FREELANCE','NDA','SERVICE','EMPLOYMENT','OTHER','UNKNOWN');
+
+-- ── 3. analysis_results에 누락된 컬럼 추가 ─────────────────────────────────
+-- raw_ocr_text: OCR 원문 (디버깅/재분석용)
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'analysis_results' AND COLUMN_NAME = 'raw_ocr_text');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE analysis_results ADD COLUMN raw_ocr_text TEXT NULL',
+  'SELECT ''analysis_results.raw_ocr_text already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- analysis_duration_seconds: 분석 소요 시간 (성능 모니터링)
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'analysis_results' AND COLUMN_NAME = 'analysis_duration_seconds');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE analysis_results ADD COLUMN analysis_duration_seconds INT NULL',
+  'SELECT ''analysis_results.analysis_duration_seconds already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── 4. risk_clauses에 누락된 컬럼 추가 ─────────────────────────────────────
+-- evidence_clause_ids: 위험 조항의 근거 clause_id 목록 (프론트 하이라이트용)
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'risk_clauses' AND COLUMN_NAME = 'evidence_clause_ids');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE risk_clauses ADD COLUMN evidence_clause_ids JSON NULL',
+  'SELECT ''risk_clauses.evidence_clause_ids already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- evidence_text: AI가 추출한 근거 원문 발췌
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'risk_clauses' AND COLUMN_NAME = 'evidence_text');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE risk_clauses ADD COLUMN evidence_text TEXT NULL',
+  'SELECT ''risk_clauses.evidence_text already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT '마이그레이션 완료' AS result;


### PR DESCRIPTION
Closes #27

## Summary
- `chat_sessions` 테이블에 `total_message_count`, `last_message_at` 컬럼 추가 (백로그 2.1 / 2.2)
- 메시지 추가 시 `chat_service`에서 카운터·시각을 직접 갱신 (트리거 X)
- `GET /chat/sessions` 응답에 `first_question` / `last_question` / `last_answer` 추가 (백로그 2.3)
- 기존 N+1 풀로드 제거 — 세션 수와 무관하게 항상 쿼리 4회

## 변경 파일
| 파일 | 내용 |
|---|---|
| `app/models/chat.py` | `ChatSession`에 컬럼 2개 추가 |
| `scripts/migrate_2026_05_chat_session_meta.sql` | 멱등 ADD COLUMN + 기존 세션 백필 |
| `app/services/chat_service.py` | `_bump_session_counters()` 헬퍼로 자동 갱신 |
| `app/schemas/chat.py` | `ChatSessionResponse` 확장 + 목록 전용 `ChatSessionListItem` 신규 |
| `app/api/v1/chat.py` | `_fetch_message_extreme()`로 첫/마지막 메시지 단일 쿼리 조회 |

## 마이그레이션 (배포 / 로컬 머지 시 필수)
```bash
mysql -u root -p clair_db < scripts/migrate_2026_05_chat_session_meta.sql
```
멱등 처리되어 있어 여러 번 실행해도 안전합니다.

## Test plan
- [x] 마이그레이션 실행 후 `DESCRIBE chat_sessions`로 컬럼 확인
- [x] 기존 세션 2건 백필 검증 (메시지 5개 / 3개로 정확히 집계)
- [x] `send_message()` 호출 시 카운터 +2, `last_message_at` 갱신 확인
- [x] `GET /chat/sessions`에서 `first_question` / `last_question` / `last_answer` 응답 확인
- [ ] 프론트엔드 세션 카드와 필드 명칭 합 맞추기 (백로그 요구사항 그대로 사용)