### PR TITLE
feat: 위험 조항 분석 고도화 - 안전 점수 계산 및 DB 스키마 확장

### DIFF
--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -22,6 +22,7 @@ from app.services.share_service import (
     create_share, list_shares, revoke_share, share_to_response_dict,
 )
 from app.services.pdf_service import generate_contract_pdf
+from app.services.scoring import compute_safety_score
 
 router = APIRouter()
 
@@ -53,14 +54,20 @@ def api_get_contract(contract_id: int, user: User = Depends(get_current_user), d
                                           created_at=contract.analysis_result.created_at)
     risk_clauses = None
     if contract.risk_clauses:
-        risk_clauses = [RiskClauseResponse(id=rc.id, clause_number=rc.clause_number, original_text=rc.original_text,
-                                           risk_type=rc.risk_type, risk_level=rc.risk_level.value, explanation=rc.explanation,
+        risk_clauses = [RiskClauseResponse(id=rc.id, title=rc.title, clause_number=rc.clause_number,
+                                           original_text=rc.original_text, risk_type=rc.risk_type,
+                                           risk_level=rc.risk_level.value, severity_score=rc.severity_score,
+                                           confidence=rc.confidence, explanation=rc.explanation,
+                                           problematic_text=rc.problematic_text,
                                            evidence_clause_ids=rc.evidence_clause_ids, evidence_text=rc.evidence_text)
                         for rc in contract.risk_clauses]
+    score_detail = compute_safety_score(contract.risk_clauses or [])
     return ContractDetailResponse(id=contract.id, original_filename=contract.original_filename, file_size=contract.file_size,
                                   file_type=contract.file_type, status=contract.status.value, contract_type=contract.contract_type.value,
                                   extracted_text=contract.extracted_text, created_at=contract.created_at, updated_at=contract.updated_at,
-                                  analysis=analysis, risk_clauses=risk_clauses)
+                                  analysis=analysis, risk_clauses=risk_clauses,
+                                  safety_score=score_detail["score"],
+                                  safety_score_detail=score_detail)
 
 
 @router.delete("/{contract_id}", response_model=MessageResponse, summary="계약서 삭제")

--- a/app/integrations/mappers.py
+++ b/app/integrations/mappers.py
@@ -61,13 +61,17 @@ def ai_risks_to_risk_clauses(risks: list[AIRiskResult], contract_id: int) -> lis
         rows.append(
             RiskClause(
                 contract_id=contract_id,
+                title=getattr(r, "title", None),
                 clause_number=r.evidence_clause_ids[0] if r.evidence_clause_ids else None,
-                original_text=r.evidence_text,
+                original_text=r.evidence_text or getattr(r, "problematic_text", ""),
                 risk_type=r.risk_type,
                 risk_level=_AI_SEVERITY_MAP.get(r.severity, RiskLevel.MEDIUM),
+                severity_score=getattr(r, "severity_score", 5),
+                confidence=getattr(r, "confidence", 0.7),
                 explanation=r.reason,
                 evidence_clause_ids=r.evidence_clause_ids,
                 evidence_text=r.evidence_text,
+                problematic_text=getattr(r, "problematic_text", None),
             )
         )
     return rows

--- a/app/models/analysis.py
+++ b/app/models/analysis.py
@@ -82,11 +82,19 @@ class RiskClause(Base):
     clause_number = Column(String(50), nullable=True)
     # AI가 위험하다고 판단한 조항 원문
     original_text = Column(Text, nullable=False)
-    # 위험 유형 — auto_renewal | termination | liability | payment | other
+    # 사용자 친화적 위험 조항명 (한국어, Gemini 산출)
+    title = Column(String(200), nullable=True)
+    # 위험 유형 — payment | liability | termination | confidentiality | renewal | penalty | ip | etc
     risk_type = Column(String(100), nullable=False)
     risk_level = Column(Enum(RiskLevel), default=RiskLevel.MEDIUM, nullable=False)
+    # 심각도 수치 1~10 (Gemini 산출)
+    severity_score = Column(Integer, default=5, nullable=True)
+    # 분석 신뢰도 0.0~1.0 (Gemini 산출)
+    confidence = Column(Float, nullable=True)
     # AI가 생성한 위험 설명 (한국어)
     explanation = Column(Text, nullable=True)
+    # 위험 판단 근거 원문
+    problematic_text = Column(Text, nullable=True)
     # 근거가 된 조항 ID 목록 ex) ["clause-003", "clause-007"]
     # ContractClause.clause_id와 매핑 — 프론트에서 해당 조항 하이라이트에 사용
     evidence_clause_ids = Column(JSON, nullable=True)

--- a/app/schemas/contract.py
+++ b/app/schemas/contract.py
@@ -26,6 +26,8 @@ class ContractDetailResponse(BaseModel):
     updated_at: datetime
     analysis: Optional["AnalysisResultResponse"] = None
     risk_clauses: Optional[List["RiskClauseResponse"]] = None
+    safety_score: Optional[int] = None
+    safety_score_detail: Optional[Any] = None
     model_config = {"from_attributes": True}
 
 
@@ -55,11 +57,15 @@ class AnalysisResultResponse(BaseModel):
 
 class RiskClauseResponse(BaseModel):
     id: int
+    title: Optional[str] = None
     clause_number: Optional[str] = None
     original_text: str
     risk_type: str
     risk_level: str
+    severity_score: Optional[int] = None
+    confidence: Optional[float] = None
     explanation: Optional[str] = None
+    problematic_text: Optional[str] = None
     evidence_clause_ids: Optional[List[str]] = None
     evidence_text: Optional[str] = None
     model_config = {"from_attributes": True}

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+# 카테고리별 중요도 가중치
+CATEGORY_WEIGHTS: dict[str, float] = {
+    "payment":         1.2,
+    "liability":       1.8,
+    "termination":     1.5,
+    "confidentiality": 1.0,
+    "auto_renewal":    1.3,
+    "renewal":         1.3,
+    "penalty":         1.7,
+    "ip":              1.6,
+    "non_compete":     1.4,
+    "unilateral":      1.3,
+}
+
+# 위험 레벨 기본 점수
+LEVEL_SCORES: dict[str, int] = {
+    "low":    4,
+    "medium": 10,
+    "high":   20,
+}
+
+BASE_SCORE = 100
+
+
+def compute_safety_score(risk_clauses: list) -> dict:
+    """
+    계약서 안전 점수 계산.
+
+    Returns:
+        {
+            "score": int,
+            "deductions": list,
+            "total_deduction": int
+        }
+    """
+    if not risk_clauses:
+        return {"score": 95, "deductions": [], "total_deduction": 0}
+
+    deductions = []
+    total_deduction = 0
+
+    for rc in risk_clauses:
+        level = rc.risk_level.value.lower() if hasattr(rc.risk_level, "value") else str(rc.risk_level).lower()
+        level_score = LEVEL_SCORES.get(level, 10)
+        category_weight = CATEGORY_WEIGHTS.get(rc.risk_type, 1.0)
+        severity_score = rc.severity_score if rc.severity_score else 5
+        confidence = rc.confidence if rc.confidence else 0.7
+
+        deduction = round(level_score * category_weight * (severity_score / 10) * confidence)
+        total_deduction += deduction
+
+        deductions.append({
+            "title": rc.risk_type,
+            "category": rc.risk_type,
+            "risk_level": level,
+            "deduction": deduction,
+            "reason": (
+                f"{level.upper()} 위험 / "
+                f"심각도 {severity_score} / "
+                f"신뢰도 {confidence:.2f}"
+            ),
+        })
+
+    # 고위험 조항 3개 이상 추가 패널티
+    high_count = sum(
+        1 for rc in risk_clauses
+        if (rc.risk_level.value if hasattr(rc.risk_level, "value") else str(rc.risk_level)).lower() == "high"
+    )
+    if high_count >= 3:
+        extra = 10
+        total_deduction += extra
+        deductions.append({
+            "title": "복수 고위험 조항",
+            "category": "global",
+            "risk_level": "high",
+            "deduction": extra,
+            "reason": "고위험 조항이 3개 이상 존재",
+        })
+
+    final_score = max(0, BASE_SCORE - total_deduction)
+
+    return {
+        "score": final_score,
+        "deductions": deductions,
+        "total_deduction": total_deduction,
+    }


### PR DESCRIPTION
## Summary

위험 조항 분석 결과를 기반으로 안전 점수를 계산하는 로직을 구현하고, DB 스키마를 확장했습니다.

## 변경 사항

**scoring.py (신규)**
- 카테고리별 가중치 × severity × confidence 기반 감점 계산
- 고위험 조항 3개 이상 시 추가 -10점 패널티
- 감점 내역(deductions) 포함 반환

**RiskClause 모델/DB**
- title, severity_score, confidence, problematic_text 컬럼 추가

**mappers.py**
- clair-ai RiskResult의 신규 필드 매핑

**API 응답**
- `safety_score`: 최종 점수(int)
- `safety_score_detail`: 감점 내역 포함 상세 정보(dict)
- `RiskClauseResponse`에 title, severity_score, confidence, problematic_text 추가

## Test plan
- [x] `GET /api/v1/contracts/{id}` 응답에 safety_score 포함 확인
- [x] safety_score_detail에 deductions 목록 포함 확인
- [x] risk_clauses에 title, problematic_text 포함 확인

Closes #29