### PR TITLE
fix: risk_clauses DB 컬럼 누락 및 AI 응답 필드 매핑 보완

### DIFF
--- a/app/integrations/ai_models.py
+++ b/app/integrations/ai_models.py
@@ -41,11 +41,16 @@ class AIExtractionResult(BaseModel):
 
 # 위험 조항 탐지 결과 1건
 class AIRiskResult(BaseModel):
-    risk_type: str                      # auto_renewal | termination | liability | payment | other
-    severity: str                       # low | medium | high
-    reason: str                         # 위험한 이유 설명
+    risk_type: str                      # AI 응답의 category — payment | liability | termination | confidentiality | renewal | penalty | ip | dispute | warranty | privacy | etc
+    severity: str                       # low | medium | high (AI 응답의 risk_level)
+    reason: str                         # 위험한 이유 설명 (사용자 친화적)
     evidence_clause_ids: list[str] = [] # 근거 조항 ID 목록 — ContractClause.clause_id 참조
     evidence_text: str = ""             # 해당 조항에서 발췌한 원문
+    # ── 위험 조항 고도화로 추가된 필드 (clair-ai #22) ──
+    severity_score: int = 5             # 1~10 차등 심각도 — scoring.py 가중치 계산에 사용
+    confidence: float = 0.7             # 0.0~1.0 AI 신뢰도
+    title: str = ""                     # 사용자 친화적 위험 조항명 ex) "손해배상 무제한"
+    problematic_text: str = ""          # 위험 판단 근거가 된 원문
 
 
 # YOLOv8 비전 탐지 결과 1건 (인감·서명·체크 표식)

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-# 카테고리별 중요도 가중치
+# 카테고리별 중요도 가중치 — clair-ai 프롬프트가 허용하는 category 값과 동기화
+# 등록되지 않은 카테고리는 기본 1.0이 적용됨 (compute_safety_score의 .get fallback)
 CATEGORY_WEIGHTS: dict[str, float] = {
     "payment":         1.2,
     "liability":       1.8,
@@ -12,6 +13,11 @@ CATEGORY_WEIGHTS: dict[str, float] = {
     "ip":              1.6,
     "non_compete":     1.4,
     "unilateral":      1.3,
+    # clair-ai #22로 새로 도입된 카테고리
+    "dispute":         1.2,    # 분쟁 해결 (관할·중재)
+    "warranty":        1.1,    # 하자 보증
+    "privacy":         1.4,    # 개인정보 처리 — 법적 의무 강함
+    # "etc"은 의도적으로 등록하지 않음 — 기본 1.0 적용
 }
 
 # 위험 레벨 기본 점수

--- a/scripts/migrate_2026_05_risk_clause_meta.sql
+++ b/scripts/migrate_2026_05_risk_clause_meta.sql
@@ -1,0 +1,54 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- risk_clauses 메타데이터 컬럼 추가 (2026-05)
+--
+-- 추가 내역:
+--   title             VARCHAR(200) NULL  — 사용자 친화적 위험 조항명 (한국어)
+--   severity_score    INT NULL DEFAULT 5 — 1~10 심각도 수치
+--   confidence        FLOAT NULL          — 0.0~1.0 AI 신뢰도
+--   problematic_text  TEXT NULL          — 위험 판단 근거가 된 계약서 원문
+--
+-- 왜:
+--   clair-ai 위험 조항 분석이 고도화되어 차등 점수·신뢰도·제목·원문을 함께 반환.
+--   안전 점수 계산(app/services/scoring.py)에서 severity_score와 confidence를
+--   가중치로 사용. 모델(ORM)에는 컬럼 정의되어 있으나 DB에 적용 누락.
+--
+-- 실행:
+--   mysql -u root -p clair_db < scripts/migrate_2026_05_risk_clause_meta.sql
+--
+-- 멱등성:
+--   ADD COLUMN은 INFORMATION_SCHEMA로 존재 확인 후 실행 — 여러 번 돌려도 안전.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ── 1. title 추가 ──────────────────────────────────────────────────────────
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'risk_clauses' AND COLUMN_NAME = 'title');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE risk_clauses ADD COLUMN title VARCHAR(200) NULL',
+  'SELECT ''risk_clauses.title already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── 2. severity_score 추가 ─────────────────────────────────────────────────
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'risk_clauses' AND COLUMN_NAME = 'severity_score');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE risk_clauses ADD COLUMN severity_score INT NULL DEFAULT 5',
+  'SELECT ''risk_clauses.severity_score already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── 3. confidence 추가 ─────────────────────────────────────────────────────
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'risk_clauses' AND COLUMN_NAME = 'confidence');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE risk_clauses ADD COLUMN confidence FLOAT NULL',
+  'SELECT ''risk_clauses.confidence already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── 4. problematic_text 추가 ───────────────────────────────────────────────
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'risk_clauses' AND COLUMN_NAME = 'problematic_text');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE risk_clauses ADD COLUMN problematic_text TEXT NULL',
+  'SELECT ''risk_clauses.problematic_text already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'risk_clauses 메타데이터 마이그레이션 완료' AS result;


### PR DESCRIPTION
Closes #31

## Summary
- `risk_clauses` 테이블에 누락됐던 4개 컬럼 추가 (`title` / `severity_score` / `confidence` / `problematic_text`)
- `AIRiskResult` Pydantic 모델에 새 필드 정의 — AI 차등 점수가 ORM까지 전달되도록
- `scoring.py` 가중치에 clair-ai #22 신규 카테고리(`dispute` / `warranty` / `privacy`) 추가

## 배경
clair-ai PR #22로 위험 조항 분석이 고도화되어 응답에 `severity_score` (1~10), `confidence` (0~1), `title`, `problematic_text` 필드가 추가됐는데, 백엔드 측에는:
- ORM 모델만 추가되고 **DB 마이그레이션 누락** → 새 분석 시 `Unknown column 'title'` 에러
- **Pydantic 모델에 새 필드 미정의** → `extra='ignore'`로 silent drop → 안전 점수가 모두 동일 가중치로 계산되어 변별력 없음

## 변경 파일
| 파일 | 변경 |
|---|---|
| `scripts/migrate_2026_05_risk_clause_meta.sql` | 신규 — 멱등 ADD COLUMN 4개 |
| `app/integrations/ai_models.py` | `AIRiskResult`에 4개 필드 추가 + 카테고리 주석 갱신 |
| `app/services/scoring.py` | `CATEGORY_WEIGHTS`에 dispute/warranty/privacy 추가 |

## 마이그레이션 (배포 / 로컬 머지 시 필수)
```bash
mysql -u root -p clair_db < scripts/migrate_2026_05_risk_clause_meta.sql
```
멱등 처리되어 있어 여러 번 실행해도 안전합니다.

## Test plan
- [x] 마이그레이션 실행 후 `DESCRIBE risk_clauses` — 컬럼 14개 확인
- [x] Pydantic 파싱 — `severity_score=9, confidence=0.85, title='손해배상 무제한'` 정상 수용
- [x] mappers.py ORM 변환 — 새 필드들이 `RiskClause` 객체에 전달되는지 확인
- [x] `compute_safety_score` — 차등 점수 반영 (예: 같은 high에서 severity_score=9 → 72점, 5 → 87점)
- [ ] 실제 새 계약서 업로드 + 분석 시 SQL 에러 없이 완료되는지 (수동 확인)

## 별건 — AI 팀 요청
Gemini 분기에서 `evidence_clause_ids`가 항상 빈 배열 → 프론트의 위험 조항 클릭 → 본문 점프 기능에 영향. 다음 AI 작업 때 프롬프트에 해당 필드 복구 요청.