### PR TITLE
fix: AIRiskResult 신규 필드 누락으로 분석 태스크 실패하던 문제 수정

### DIFF
--- a/app/integrations/ai_models.py
+++ b/app/integrations/ai_models.py
@@ -41,11 +41,15 @@ class AIExtractionResult(BaseModel):
 
 # 위험 조항 탐지 결과 1건
 class AIRiskResult(BaseModel):
-    risk_type: str                      # auto_renewal | termination | liability | payment | other
-    severity: str                       # low | medium | high
-    reason: str                         # 위험한 이유 설명
-    evidence_clause_ids: list[str] = [] # 근거 조항 ID 목록 — ContractClause.clause_id 참조
-    evidence_text: str = ""             # 해당 조항에서 발췌한 원문
+    risk_type: str                          # auto_renewal | termination | liability | payment | other
+    severity: str                           # low | medium | high
+    reason: str = ""                        # 위험한 이유 설명
+    evidence_clause_ids: list[str] = []     # 근거 조항 ID 목록
+    evidence_text: str = ""                 # 해당 조항에서 발췌한 원문
+    title: Optional[str] = None             # 한국어 위험 조항명 (예: "손해배상 무제한")
+    severity_score: int = 5                 # 심각도 수치 1~10
+    confidence: float = 0.7                 # 분석 신뢰도 0.0~1.0
+    problematic_text: str = ""              # 위험 판단 근거 원문
 
 
 # YOLOv8 비전 탐지 결과 1건 (인감·서명·체크 표식)


### PR DESCRIPTION
## 문제

clair-ai가 위험 조항 분석 결과에 `title`, `severity_score`, `confidence`, `problematic_text` 필드를 추가했는데, 백엔드의 `AIRiskResult` Pydantic 모델에 해당 필드가 없었음.

이로 인해 `AIAnalysisResponse.model_validate()` 시 validation 에러가 발생하고, FastAPI BackgroundTask에서 예외가 조용히 삼켜지면서 계약서 상태가 PROCESSING에서 멈추는 현상 발생.

## 수정

`app/integrations/ai_models.py`의 `AIRiskResult`에 누락된 필드 추가 (모두 Optional/기본값으로 하위 호환 유지):
- `title: Optional[str] = None`
- `severity_score: int = 5`
- `confidence: float = 0.7`
- `problematic_text: str = ""`

## Test plan
- [ ] 계약서 업로드 후 분석 요청 시 PROCESSING → COMPLETED 정상 전환 확인
- [ ] 결과 페이지에서 위험 조항 목록 정상 표시 확인