### PR TITLE
fix: 비밀번호 재설정 confirm 스키마에서 new_password_confirm 제거

### DIFF
--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -123,7 +123,6 @@ class PasswordResetRequest(BaseModel):
 class PasswordResetConfirmRequest(BaseModel):
     token: str
     new_password: str
-    new_password_confirm: str
 
     @field_validator("new_password")
     @classmethod
@@ -131,12 +130,6 @@ class PasswordResetConfirmRequest(BaseModel):
         if len(v) < 8:
             raise ValueError("새 비밀번호는 8자 이상이어야 합니다.")
         return v
-
-    @model_validator(mode="after")
-    def passwords_match(self):
-        if self.new_password != self.new_password_confirm:
-            raise ValueError("비밀번호가 일치하지 않습니다.")
-        return self
 
 
 class PasswordResetVerifyResponse(BaseModel):


### PR DESCRIPTION
## Summary
- `PasswordResetConfirmRequest`에서 `new_password_confirm` 필드와 `passwords_match` 모델 검증 제거
- 비밀번호 재입력 일치 확인은 UX 영역(클라이언트 책임)이며, 서버에서 요구해도 보안적 이득은 없고 계약 불일치만 만듦

Closes #35

## Test plan
- [ ] `POST /api/v1/auth/password-reset/confirm`에 `{ token, new_password }`만 보냈을 때 422 대신 정상 처리되는지 확인
- [ ] 유효하지 않은 토큰일 때 `{ "detail": "유효하지 않은 토큰입니다." }` 형태(문자열)로 400 응답
- [ ] 8자 미만 비밀번호일 때 422가 떨어지더라도 프론트가 안전하게 렌더(별건이지만 함께 확인)