### PR TITLE
fix: 안전 점수 최솟값 0 → 25 보정 (감점 초과 시 0점 방지)

### DIFF
--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -79,7 +79,7 @@ def compute_safety_score(risk_clauses: list) -> dict:
             "reason": "고위험 조항이 3개 이상 존재",
         })
 
-    final_score = max(0, BASE_SCORE - total_deduction)
+    final_score = max(25, BASE_SCORE - total_deduction)
 
     return {
         "score": final_score,


### PR DESCRIPTION
closes #37

## 변경 내용

위험 조항이 많은 계약서에서 총 감점이 100점을 초과할 때 안전 점수가 0점이 되는 문제 수정.
최솟값을 25점으로 보장하여 실제 위험도를 반영한 합리적인 점수가 출력되도록 개선.

```python
# 변경 전
final_score = max(0, BASE_SCORE - total_deduction)

# 변경 후
final_score = max(25, BASE_SCORE - total_deduction)
```

## 테스트

근로계약서 (고위험 3개, 중위험 8개) 분석 결과:
- 변경 전: 0점
- 변경 후: 25점 (총 감점 126점 → 상한 적용)

## 수정 파일
- `app/services/scoring.py` 1줄