### PR TITLE
feat: 프로필 이미지 업로드 API 추가

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, UploadFile
 from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
@@ -16,6 +16,7 @@ from app.schemas.auth import (
 from app.schemas.contract import MessageResponse
 from app.services.auth_service import (
     signup, login, refresh_access_token, update_nickname, change_password,
+    update_profile_image, profile_image_url,
     request_password_reset, verify_reset_token, confirm_password_reset,
     get_google_auth_url, google_login,
     get_naver_auth_url, naver_login,
@@ -23,6 +24,19 @@ from app.services.auth_service import (
 )
 
 router = APIRouter()
+
+
+def _to_my_info(user: User) -> MyInfoResponse:
+    return MyInfoResponse(
+        id=user.id,
+        email=user.email,
+        nickname=user.nickname,
+        has_password=user.password_hash is not None,
+        profile_image=profile_image_url(user),
+        marketing_agreed=user.marketing_agreed,
+        created_at=user.created_at,
+        updated_at=user.updated_at,
+    )
 
 
 @router.post("/signup", response_model=SignUpResponse, status_code=201, summary="회원가입")
@@ -48,35 +62,27 @@ def api_refresh(body: RefreshRequest, db: Session = Depends(get_db)):
 
 @router.get("/me", response_model=MyInfoResponse, summary="내 정보 조회")
 def api_my_info(user: User = Depends(get_current_user)):
-    return MyInfoResponse(
-        id=user.id,
-        email=user.email,
-        nickname=user.nickname,
-        has_password=user.password_hash is not None,
-        marketing_agreed=user.marketing_agreed,
-        created_at=user.created_at,
-        updated_at=user.updated_at,
-    )
+    return _to_my_info(user)
 
 
 @router.patch("/me/nickname", response_model=MyInfoResponse, summary="닉네임 변경")
 def api_update_nickname(body: UpdateNicknameRequest, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
-    updated = update_nickname(user, body.nickname, db)
-    return MyInfoResponse(
-        id=updated.id,
-        email=updated.email,
-        nickname=updated.nickname,
-        has_password=updated.password_hash is not None,
-        marketing_agreed=updated.marketing_agreed,
-        created_at=updated.created_at,
-        updated_at=updated.updated_at,
-    )
+    return _to_my_info(update_nickname(user, body.nickname, db))
 
 
 @router.patch("/me/password", response_model=MessageResponse, summary="비밀번호 변경")
 def api_change_password(body: ChangePasswordRequest, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     change_password(user=user, current_password=body.current_password, new_password=body.new_password, db=db)
     return MessageResponse(message="비밀번호가 변경되었습니다.")
+
+
+@router.post("/me/profile-image", response_model=MyInfoResponse, summary="프로필 이미지 업로드")
+async def api_upload_profile_image(
+    file: UploadFile = File(..., description="프로필 이미지 (PNG/JPG/JPEG, 최대 5MB)"),
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return _to_my_info(await update_profile_image(user=user, file=file, db=db))
 
 
 # ── 비밀번호 재설정 (비로그인 상태에서 이메일 링크로) ─────────────────────────

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,6 +16,10 @@ class Settings(BaseSettings):
     max_file_size_mb: int = 20
     allowed_extensions: str = ".pdf,.png,.jpg,.jpeg,.txt,.docx"
 
+    backend_base_url: str = "http://localhost:8000"
+    profile_image_max_size_mb: int = 5
+    profile_image_allowed_extensions: str = ".png,.jpg,.jpeg"
+
     secret_key: str = "change-this-to-random-secret-key"
     access_token_expire_minutes: int = 60
     refresh_token_expire_days: int = 7
@@ -68,6 +72,14 @@ class Settings(BaseSettings):
     @property
     def cors_origins_list(self) -> List[str]:
         return [origin.strip() for origin in self.cors_origins.split(",")]
+
+    @property
+    def profile_image_allowed_extensions_list(self) -> List[str]:
+        return [ext.strip() for ext in self.profile_image_allowed_extensions.split(",")]
+
+    @property
+    def profile_image_max_size_bytes(self) -> int:
+        return self.profile_image_max_size_mb * 1024 * 1024
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
 from contextlib import asynccontextmanager
+from pathlib import Path
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from app.core.config import settings
 from app.db.init_db import init_db
 from app.api.v1.auth import router as auth_router
@@ -8,6 +10,7 @@ from app.api.v1.contracts import router as contracts_router
 from app.api.v1.chat import router as chat_router
 from app.api.v1.notifications import router as notifications_router
 from app.api.v1.shares import router as shares_router
+from app.services.auth_service import PROFILE_IMAGE_SUBDIR
 
 
 @asynccontextmanager
@@ -27,6 +30,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# 프로필 이미지만 정적 서빙 — 계약서 파일이 있는 UPLOAD_DIR 전체를 노출하지 않기 위해 하위 디렉토리만 마운트
+_profile_image_dir = Path(settings.upload_dir) / PROFILE_IMAGE_SUBDIR
+_profile_image_dir.mkdir(parents=True, exist_ok=True)
+app.mount(f"/{PROFILE_IMAGE_SUBDIR}", StaticFiles(directory=str(_profile_image_dir)), name="profile-images")
 
 app.include_router(auth_router, prefix="/api/v1/auth", tags=["인증"])
 app.include_router(contracts_router, prefix="/api/v1/contracts", tags=["계약서"])

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -9,6 +9,7 @@ class User(Base):
     email = Column(String(255), unique=True, nullable=False, index=True)
     nickname = Column(String(100), nullable=False)
     password_hash = Column(String(255), nullable=True)
+    profile_image_path = Column(String(500), nullable=True)
     created_at = Column(DateTime, server_default=func.now())
     marketing_agreed = Column(Boolean, nullable=False, default=False, server_default="0")
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -77,6 +77,7 @@ class MyInfoResponse(BaseModel):
     email: str
     nickname: str
     has_password: bool
+    profile_image: Optional[str] = None
     marketing_agreed: bool
     created_at: datetime
     updated_at: datetime

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,8 +1,12 @@
 import hashlib
+import os
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
 from urllib.parse import urlencode, quote
-from fastapi import HTTPException, status
+from fastapi import HTTPException, UploadFile, status
 from sqlalchemy.orm import Session
 import httpx
 from app.core.config import settings
@@ -11,6 +15,16 @@ from app.models.user import User
 from app.models.social_account import SocialAccount
 from app.models.password_reset import PasswordResetToken
 from app.integrations.email_client import send_email
+
+
+PROFILE_IMAGE_SUBDIR = "profile_images"
+
+
+def profile_image_url(user: User) -> Optional[str]:
+    """DB의 상대 경로를 backend_base_url과 조합한 절대 URL로 변환. 없으면 None."""
+    if not user.profile_image_path:
+        return None
+    return f"{settings.backend_base_url.rstrip('/')}/{user.profile_image_path.lstrip('/')}"
 
 
 def signup(email: str, nickname: str, password: str, db: Session, marketing_agreed: bool = False) -> User:
@@ -53,6 +67,58 @@ def update_nickname(user: User, new_nickname: str, db: Session) -> User:
     user.nickname = new_nickname.strip()
     db.commit()
     db.refresh(user)
+    return user
+
+
+async def update_profile_image(user: User, file: UploadFile, db: Session) -> User:
+    if not file.filename:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="파일명이 없습니다.")
+    ext = Path(file.filename).suffix.lower()
+    if ext not in settings.profile_image_allowed_extensions_list:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"지원하지 않는 이미지 형식입니다: {ext} (허용: {settings.profile_image_allowed_extensions})",
+        )
+
+    profile_dir = Path(settings.upload_dir) / PROFILE_IMAGE_SUBDIR
+    profile_dir.mkdir(parents=True, exist_ok=True)
+
+    stored_filename = f"{user.id}_{uuid.uuid4().hex}{ext}"
+    file_path = profile_dir / stored_filename
+
+    size = 0
+    try:
+        with open(file_path, "wb") as f:
+            while chunk := await file.read(1024 * 1024):
+                size += len(chunk)
+                if size > settings.profile_image_max_size_bytes:
+                    f.close()
+                    os.remove(file_path)
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail=f"이미지 크기가 {settings.profile_image_max_size_mb}MB를 초과합니다.",
+                    )
+                f.write(chunk)
+    except HTTPException:
+        raise
+    except Exception as e:
+        if file_path.exists():
+            os.remove(file_path)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"파일 저장 중 오류: {e}")
+
+    old_relative = user.profile_image_path
+    user.profile_image_path = f"{PROFILE_IMAGE_SUBDIR}/{stored_filename}"
+    db.commit()
+    db.refresh(user)
+
+    if old_relative:
+        old_path = Path(settings.upload_dir) / old_relative
+        try:
+            if old_path.is_file():
+                old_path.unlink()
+        except OSError:
+            pass
+
     return user
 
 

--- a/scripts/migrate_2026_05_user_profile_image.sql
+++ b/scripts/migrate_2026_05_user_profile_image.sql
@@ -1,0 +1,25 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- users 테이블에 profile_image_path 컬럼 추가 (2026-05)
+--
+-- 추가 내역:
+--   profile_image_path VARCHAR(500) NULL  — 프로필 이미지 상대 경로
+--
+-- 왜:
+--   마이페이지에서 프로필 이미지 업로드/표시가 필요. 절대 URL은 매번 응답 시점에
+--   backend_base_url과 조합해 만들기 때문에 DB에는 파일 시스템 상대 경로만 저장.
+--
+-- 실행:
+--   mysql -u root -p clair_db < scripts/migrate_2026_05_user_profile_image.sql
+--
+-- 멱등성:
+--   ADD COLUMN은 INFORMATION_SCHEMA로 존재 확인 후 실행 — 여러 번 돌려도 안전.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users' AND COLUMN_NAME = 'profile_image_path');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE users ADD COLUMN profile_image_path VARCHAR(500) NULL',
+  'SELECT ''users.profile_image_path already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'users.profile_image_path 마이그레이션 완료' AS result;


### PR DESCRIPTION
## Summary
- `POST /api/v1/auth/me/profile-image` (multipart, PNG/JPG/JPEG, 5MB 이하) 추가
- `/auth/me`, `PATCH /me/nickname` 응답에 `profile_image` 절대 URL 포함
- `users.profile_image_path` 컬럼 추가 (멱등 SQL 마이그레이션)
- 프로필 이미지 디렉토리만 정적 서빙(`/profile_images/`) — `UPLOAD_DIR` 전체를 노출하지 않기 위해 하위 경로만 마운트
- 재업로드 시 이전 파일 삭제

Closes #41

## 🚨 DB 마이그레이션 필수
pull 받은 후 **반드시** 아래 명령을 실행해야 `users` 조회가 깨지지 않습니다:

\`\`\`bash
mysql -u root -p clair_db < scripts/migrate_2026_05_user_profile_image.sql
\`\`\`

(멱등성 처리돼 있어 여러 번 실행해도 안전)

## 환경 변수
- `BACKEND_BASE_URL` (선택, 기본 `http://localhost:8000`) — 응답에 내려갈 절대 URL prefix
- `PROFILE_IMAGE_MAX_SIZE_MB` (선택, 기본 5)
- `PROFILE_IMAGE_ALLOWED_EXTENSIONS` (선택, 기본 `.png,.jpg,.jpeg`)

## API 사용 예
\`\`\`
POST /api/v1/auth/me/profile-image
Authorization: Bearer <token>
Content-Type: multipart/form-data

file: <image file>
\`\`\`
응답: `MyInfoResponse` (`profile_image` 필드에 절대 URL)

## Test plan
- [ ] 마이그레이션 후 서버 기동, `/auth/me` 응답에 `profile_image: null`
- [ ] PNG 업로드 → 200 + `profile_image` URL 반환, 해당 URL GET 시 이미지 다운로드
- [ ] 재업로드 → 새 URL 반환 + 이전 파일 디스크에서 삭제
- [ ] `.gif` 등 비허용 확장자 → 400
- [ ] 5MB 초과 파일 → 413
- [ ] 토큰 없이 호출 → 401