### PR TITLE
feat: 회원가입 전 이메일 코드 인증 단계 추가

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -12,11 +12,13 @@ from app.schemas.auth import (
     MyInfoResponse, UpdateNicknameRequest, ChangePasswordRequest,
     SocialLoginResponse,
     PasswordResetRequest, PasswordResetConfirmRequest, PasswordResetVerifyResponse,
+    EmailVerificationRequest, EmailVerificationConfirmRequest,
 )
 from app.schemas.contract import MessageResponse
 from app.services.auth_service import (
     signup, login, refresh_access_token, update_nickname, change_password,
     request_password_reset, verify_reset_token, confirm_password_reset,
+    request_email_verification, confirm_email_verification,
     get_google_auth_url, google_login,
     get_naver_auth_url, naver_login,
     get_kakao_auth_url, kakao_login,
@@ -98,6 +100,20 @@ def api_verify_reset_token(token: str, db: Session = Depends(get_db)):
 def api_confirm_password_reset(body: PasswordResetConfirmRequest, db: Session = Depends(get_db)):
     confirm_password_reset(raw_token=body.token, new_password=body.new_password, db=db)
     return MessageResponse(message="비밀번호가 재설정되었습니다. 새 비밀번호로 로그인해주세요.")
+
+
+# ── 회원가입 이메일 인증 (가입 전 6자리 코드 확인) ─────────────────────────────
+
+@router.post("/email-verification/request", response_model=MessageResponse, summary="이메일 인증 코드 발송")
+async def api_request_email_verification(body: EmailVerificationRequest, db: Session = Depends(get_db)):
+    await request_email_verification(email=body.email, db=db)
+    return MessageResponse(message="입력하신 이메일로 인증 코드를 발송했습니다. 메일이 오지 않으면 스팸함을 확인해주세요.")
+
+
+@router.post("/email-verification/confirm", response_model=MessageResponse, summary="이메일 인증 코드 확인")
+def api_confirm_email_verification(body: EmailVerificationConfirmRequest, db: Session = Depends(get_db)):
+    confirm_email_verification(email=body.email, code=body.code, db=db)
+    return MessageResponse(message="이메일 인증이 완료되었습니다. 회원가입을 진행해주세요.")
 
 
 # ── Google ────────────────────────────────────────────────────────────────────

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -49,6 +49,9 @@ class Settings(BaseSettings):
     password_reset_path: str = "/password-reset"
     password_reset_token_expire_minutes: int = 30
 
+    email_verification_code_expire_minutes: int = 10
+    email_verification_max_attempts: int = 5
+
     share_path: str = "/share"
     share_token_default_expire_days: int = 7
     share_access_token_expire_minutes: int = 60

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -1,5 +1,5 @@
 from app.db.session import engine, Base
-from app.models import user, contract, analysis, chat, social_account, notification, password_reset, contract_share  # noqa: F401
+from app.models import user, contract, analysis, chat, social_account, notification, password_reset, contract_share, email_verification  # noqa: F401
 
 
 def init_db():

--- a/app/models/email_verification.py
+++ b/app/models/email_verification.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, Integer, String, DateTime, func
+from app.db.session import Base
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# EmailVerification: 회원가입 전 단계의 이메일 코드 인증
+#
+# 이메일당 활성 레코드 1개 (UNIQUE) — 코드 재요청 시 같은 행을 갱신.
+# code_hash만 저장: DB 유출 시에도 raw 6자리 코드는 알 수 없음.
+# attempt_count로 confirm 무차별 대입 방어 — 5회 실패 시 코드 무효.
+# verified_at 채워진 레코드는 회원가입 시 1회용으로 소비된 뒤 삭제됨.
+# ──────────────────────────────────────────────────────────────────────────────
+class EmailVerification(Base):
+    __tablename__ = "email_verifications"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    code_hash = Column(String(64), nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    attempt_count = Column(Integer, nullable=False, default=0, server_default="0")
+    verified_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, server_default=func.now())

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -9,6 +9,7 @@ class User(Base):
     email = Column(String(255), unique=True, nullable=False, index=True)
     nickname = Column(String(100), nullable=False)
     password_hash = Column(String(255), nullable=True)
+    email_verified_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, server_default=func.now())
     marketing_agreed = Column(Boolean, nullable=False, default=False, server_default="0")
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -135,3 +135,22 @@ class PasswordResetConfirmRequest(BaseModel):
 class PasswordResetVerifyResponse(BaseModel):
     valid: bool
     email: Optional[str] = None
+
+
+# ── 회원가입 이메일 인증 (가입 전 코드 확인) ─────────────────────────────────
+
+class EmailVerificationRequest(BaseModel):
+    email: EmailStr
+
+
+class EmailVerificationConfirmRequest(BaseModel):
+    email: EmailStr
+    code: str
+
+    @field_validator("code")
+    @classmethod
+    def code_format(cls, v):
+        v = v.strip()
+        if not (v.isdigit() and len(v) == 6):
+            raise ValueError("인증 코드는 6자리 숫자여야 합니다.")
+        return v

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -10,6 +10,7 @@ from app.core.security import hash_password, verify_password, create_access_toke
 from app.models.user import User
 from app.models.social_account import SocialAccount
 from app.models.password_reset import PasswordResetToken
+from app.models.email_verification import EmailVerification
 from app.integrations.email_client import send_email
 
 
@@ -17,8 +18,24 @@ def signup(email: str, nickname: str, password: str, db: Session, marketing_agre
     existing = db.query(User).filter(User.email == email).first()
     if existing:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="이미 가입된 이메일입니다.")
-    user = User(email=email, nickname=nickname.strip(), password_hash=hash_password(password), marketing_agreed=marketing_agreed)
+
+    # 가입 전 이메일 인증 통과 여부 확인 — verified 레코드는 가입 시점에 1회용으로 소비.
+    verification = db.query(EmailVerification).filter(EmailVerification.email == email).first()
+    if not verification or verification.verified_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="이메일 인증이 필요합니다. 인증 코드를 먼저 확인해주세요.",
+        )
+
+    user = User(
+        email=email,
+        nickname=nickname.strip(),
+        password_hash=hash_password(password),
+        marketing_agreed=marketing_agreed,
+        email_verified_at=datetime.now(timezone.utc),
+    )
     db.add(user)
+    db.delete(verification)  # 인증 레코드는 가입 시 소비
     db.commit()
     db.refresh(user)
     return user
@@ -140,10 +157,97 @@ def confirm_password_reset(raw_token: str, new_password: str, db: Session) -> No
     db.commit()
 
 
+# ── 회원가입 이메일 인증 (가입 전 6자리 코드 확인) ─────────────────────────────
+
+def _hash_code(code: str) -> str:
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+def _generate_code() -> str:
+    """6자리 숫자 코드 — secrets로 균등 분포."""
+    return f"{secrets.randbelow(1_000_000):06d}"
+
+
+async def request_email_verification(email: str, db: Session) -> None:
+    """
+    이메일로 6자리 인증 코드 발송.
+    이메일당 활성 레코드 1개 — 재요청 시 기존 레코드의 코드/만료/시도횟수를 새로 채움.
+    이미 가입된 이메일이면 정보 노출 회피 위해 그대로 진행 (가입은 signup 단계에서 막힘).
+    """
+    code = _generate_code()
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=settings.email_verification_code_expire_minutes)
+
+    record = db.query(EmailVerification).filter(EmailVerification.email == email).first()
+    if record:
+        record.code_hash = _hash_code(code)
+        record.expires_at = expires_at
+        record.attempt_count = 0
+        record.verified_at = None
+    else:
+        record = EmailVerification(email=email, code_hash=_hash_code(code), expires_at=expires_at)
+        db.add(record)
+    db.commit()
+
+    await send_email(
+        to=email,
+        subject="[CLAIR] 이메일 인증 코드",
+        template="email_verification.html",
+        context={
+            "code": code,
+            "expire_minutes": settings.email_verification_code_expire_minutes,
+        },
+    )
+
+
+def confirm_email_verification(email: str, code: str, db: Session) -> None:
+    """
+    코드 검증 → 성공 시 verified_at 채움. 실패 누적 5회 시 코드 무효.
+    한 트랜잭션 내에서 attempt_count도 함께 증가시켜야 무차별 대입을 막을 수 있음.
+    """
+    record = db.query(EmailVerification).filter(EmailVerification.email == email).first()
+    if not record:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="인증 요청 내역이 없습니다. 코드를 다시 요청해주세요.",
+        )
+
+    expires_at = record.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if datetime.now(timezone.utc) > expires_at:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="만료된 코드입니다. 인증 코드를 다시 요청해주세요.",
+        )
+
+    if record.attempt_count >= settings.email_verification_max_attempts:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="시도 횟수를 초과했습니다. 인증 코드를 다시 요청해주세요.",
+        )
+
+    if record.code_hash != _hash_code(code):
+        record.attempt_count += 1
+        db.commit()
+        remaining = settings.email_verification_max_attempts - record.attempt_count
+        if remaining <= 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="시도 횟수를 초과했습니다. 인증 코드를 다시 요청해주세요.",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"인증 코드가 올바르지 않습니다. (남은 시도 {remaining}회)",
+        )
+
+    record.verified_at = datetime.now(timezone.utc)
+    db.commit()
+
+
 # ── 공통 소셜 로그인 처리 ──────────────────────────────────────────────────────
 
 def _social_login(provider: str, provider_id: str, email: str, nickname: str, db: Session) -> dict:
-    """소셜 계정으로 유저 찾기 → 없으면 생성, JWT 발급"""
+    """소셜 계정으로 유저 찾기 → 없으면 생성, JWT 발급. 소셜 유저는 IdP 신뢰로 자동 verified."""
     social = (
         db.query(SocialAccount)
         .filter(SocialAccount.provider == provider, SocialAccount.provider_id == provider_id)
@@ -151,16 +255,22 @@ def _social_login(provider: str, provider_id: str, email: str, nickname: str, db
     )
 
     is_new_user = False
+    now = datetime.now(timezone.utc)
 
     if social:
         user = social.user
+        # 기존 이메일 가입자가 같은 이메일로 소셜 연결한 케이스: 아직 미인증이면 이번에 채움.
+        if user.email_verified_at is None:
+            user.email_verified_at = now
     else:
         user = db.query(User).filter(User.email == email).first()
-        if not user:
-            user = User(email=email, nickname=nickname[:20], password_hash=None)
+        if user is None:
+            user = User(email=email, nickname=nickname[:20], password_hash=None, email_verified_at=now)
             db.add(user)
             db.flush()  # user.id 확보
             is_new_user = True
+        elif user.email_verified_at is None:
+            user.email_verified_at = now
 
         social = SocialAccount(user_id=user.id, provider=provider, provider_id=str(provider_id))
         db.add(social)

--- a/app/templates/emails/email_verification.html
+++ b/app/templates/emails/email_verification.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>CLAIR 이메일 인증 코드</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f6f7fb;font-family:'Apple SD Gothic Neo',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f6f7fb;padding:40px 0;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.05);">
+          <tr>
+            <td style="padding:40px 40px 0 40px;">
+              <h1 style="margin:0 0 8px 0;font-size:22px;color:#111827;">이메일 인증 코드</h1>
+              <p style="margin:0;color:#6b7280;font-size:14px;">CLAIR</p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 40px 0 40px;">
+              <p style="margin:0 0 16px 0;color:#374151;font-size:14px;line-height:1.6;">
+                CLAIR 회원가입을 위한 이메일 인증 코드를 안내드립니다.<br>
+                아래 코드를 가입 화면에 입력해 주세요.
+              </p>
+              <p style="margin:0 0 24px 0;color:#9ca3af;font-size:13px;line-height:1.6;">
+                이 코드는 <strong>{{ expire_minutes }}분간</strong> 유효합니다.
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:0 40px 32px 40px;">
+              <div style="display:inline-block;padding:18px 32px;background:#f3f4f6;border-radius:10px;font-family:'SF Mono','Menlo','Consolas',monospace;font-size:28px;font-weight:700;letter-spacing:8px;color:#111827;">
+                {{ code }}
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="border-top:1px solid #e5e7eb;padding:24px 40px;background:#fafafa;">
+              <p style="margin:0;color:#9ca3af;font-size:12px;line-height:1.6;">
+                본인이 요청하지 않은 메일이라면 이 메일을 무시하셔도 됩니다.
+              </p>
+            </td>
+          </tr>
+        </table>
+
+        <p style="margin:16px 0 0 0;color:#9ca3af;font-size:11px;">
+          © CLAIR. This is an automated message — please do not reply.
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/scripts/migrate_2026_05_email_verification.sql
+++ b/scripts/migrate_2026_05_email_verification.sql
@@ -1,0 +1,53 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 회원가입 이메일 인증 (2026-05)
+--
+-- 추가 내역:
+--   1) email_verifications 테이블 신설 — 가입 전 단계의 6자리 코드 인증
+--      · email          VARCHAR(255) NOT NULL  — 인증 대상 이메일
+--      · code_hash      VARCHAR(64)  NOT NULL  — 6자리 코드의 SHA-256 해시
+--      · expires_at     DATETIME     NOT NULL  — 코드 만료 시각 (요청 후 10분)
+--      · attempt_count  INT          NOT NULL DEFAULT 0  — confirm 실패 누적 (5회 시 무효)
+--      · verified_at    DATETIME     NULL      — 인증 완료 시각
+--      · created_at     DATETIME              DEFAULT CURRENT_TIMESTAMP
+--      · UNIQUE INDEX(email) — 이메일당 활성 인증 레코드 1개 보장 (재요청 시 UPSERT)
+--
+--   2) users.email_verified_at DATETIME NULL — 가입 시점에 채워짐 (소셜 유저는 IdP 신뢰로 자동 채움)
+--
+-- 왜:
+--   가입 전 코드 인증 흐름 — 미인증 유저가 DB에 남지 않도록 회원가입 전에 별도 검증 단계.
+--   소셜 로그인은 IdP가 이메일 소유권을 검증한 뒤 넘겨주므로 추가 단계 없이 verified 처리.
+--
+-- 실행:
+--   mysql -u root -p clair_db < scripts/migrate_2026_05_email_verification.sql
+--
+-- 멱등성:
+--   테이블/컬럼은 INFORMATION_SCHEMA로 존재 확인 후 실행 — 여러 번 돌려도 안전.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ── 1. email_verifications 테이블 ──────────────────────────────────────────
+SET @tbl_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'email_verifications');
+SET @sql := IF(@tbl_exists = 0,
+  'CREATE TABLE email_verifications (
+     id            INT          NOT NULL AUTO_INCREMENT,
+     email         VARCHAR(255) NOT NULL,
+     code_hash     VARCHAR(64)  NOT NULL,
+     expires_at    DATETIME     NOT NULL,
+     attempt_count INT          NOT NULL DEFAULT 0,
+     verified_at   DATETIME     NULL,
+     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     PRIMARY KEY (id),
+     UNIQUE KEY uq_email_verifications_email (email)
+   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+  'SELECT ''email_verifications already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── 2. users.email_verified_at ─────────────────────────────────────────────
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users' AND COLUMN_NAME = 'email_verified_at');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE users ADD COLUMN email_verified_at DATETIME NULL',
+  'SELECT ''users.email_verified_at already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'email_verifications + users.email_verified_at 마이그레이션 완료' AS result;


### PR DESCRIPTION
## Summary
- 가입 전 단계에서 6자리 코드 메일 인증을 필수화
- 미인증 이메일로는 `POST /auth/signup` 차단
- 코드 만료 10분, 5회 실패 시 코드 무효(재요청 필요)
- 소셜 로그인 유저는 IdP가 이메일 소유권을 검증하므로 자동 verified 처리 — 별도 인증 단계 불필요

Closes #43

## 🚨 DB 마이그레이션 필수
pull 후 **반드시** 아래 명령을 실행해야 합니다. 안 돌리면 회원가입·로그인이 `Unknown column 'users.email_verified_at'`로 깨집니다:

\`\`\`bash
mysql -u root -p clair_db < scripts/migrate_2026_05_email_verification.sql
\`\`\`

(멱등성 처리돼 있어 여러 번 실행해도 안전)

## 새 엔드포인트
- `POST /api/v1/auth/email-verification/request` { `email` } → 6자리 코드 메일 발송
- `POST /api/v1/auth/email-verification/confirm` { `email`, `code` } → DB에 `verified_at` 마킹

가입 흐름은 그대로 `POST /api/v1/auth/signup`이지만, 인증 안 된 이메일이면 `400 "이메일 인증이 필요합니다."`로 거부됩니다. 가입 성공 시 인증 레코드는 1회용으로 삭제됨.

## 새 설정 (선택)
- `EMAIL_VERIFICATION_CODE_EXPIRE_MINUTES` (기본 10)
- `EMAIL_VERIFICATION_MAX_ATTEMPTS` (기본 5)

## 데이터 모델
- `email_verifications` (`email` UNIQUE, `code_hash`, `expires_at`, `attempt_count`, `verified_at`, `created_at`)
- `users.email_verified_at DATETIME NULL`

소셜 로그인 분기에서도 `users.email_verified_at`를 채워 일관성 유지.

## Test plan
- [ ] 마이그레이션 실행 후 서버 정상 기동
- [ ] `email-verification/request` 호출 시 메일 수신 (`code`, `expire_minutes` 변수 정상 렌더)
- [ ] 잘못된 코드 → 400 "남은 시도 N회" 메시지
- [ ] 5회 실패 → "시도 횟수를 초과했습니다" 400, 동일 코드로 재시도 불가
- [ ] 코드 재요청 → `attempt_count` 0으로 리셋
- [ ] 만료(10분) 후 confirm → 400 "만료된 코드"
- [ ] 인증 없이 `/signup` 호출 → 400 "이메일 인증이 필요합니다"
- [ ] 인증 후 정상 signup → 201, DB의 인증 레코드 삭제됨, `users.email_verified_at` 채워짐
- [ ] 소셜 로그인 신규 유저 생성 시 `users.email_verified_at`이 자동으로 채워짐