### PR TITLE
fix: 공유 링크가 있는 계약서 삭제 시 500 오류 수정

### DIFF
--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, DateTime, Text, JSON, ForeignKey, Enum, func
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 import enum
 from app.db.session import Base
 
@@ -31,7 +31,8 @@ class ChatSession(Base):
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
 
     user = relationship("User", backref="chat_sessions")
-    contract = relationship("Contract", backref="chat_session")
+    # passive_deletes=True: Contract 삭제 시 DB의 ON DELETE SET NULL에 위임 (불필요한 ORM UPDATE 회피)
+    contract = relationship("Contract", backref=backref("chat_session", passive_deletes=True))
     messages = relationship("ChatMessage", back_populates="session", cascade="all, delete-orphan", order_by="ChatMessage.created_at")
 
 

--- a/app/models/contract_share.py
+++ b/app/models/contract_share.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, func
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 from app.db.session import Base
 
 
@@ -21,4 +21,6 @@ class ContractShare(Base):
     revoked_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, server_default=func.now())
 
-    contract = relationship("Contract", backref="shares")
+    # passive_deletes=True: Contract 삭제 시 ORM이 자식 FK를 NULL로 UPDATE하지 않고
+    # DB의 ON DELETE CASCADE에 위임 (contract_id가 NOT NULL이라 ORM UPDATE는 IntegrityError 유발)
+    contract = relationship("Contract", backref=backref("shares", passive_deletes=True))


### PR DESCRIPTION
Closes #47

## Summary
- `ContractShare.contract` backref에 `passive_deletes=True` 추가 → Contract 삭제 시 DB의 `ON DELETE CASCADE`에 위임 (기존엔 SQLAlchemy가 `contract_id`를 NULL로 UPDATE 시도하다 NOT NULL 위반으로 500 발생)
- `ChatSession.contract` backref에도 동일 적용 (nullable=True/SET NULL이라 500은 안 났지만 매번 불필요한 ORM UPDATE가 발생하던 비효율 해소)
- DB 스키마 변경 없음 → 마이그레이션 불필요

## Test plan
- [ ] 공유 링크 없는 계약서 삭제 → 200
- [ ] 공유 링크 발급 후 같은 계약서 삭제 → 200 (기존: 500)
- [ ] 삭제 후 `contract_shares` 테이블에서 해당 row가 사라졌는지 확인 (DB CASCADE 동작)
- [ ] 채팅 세션이 연결된 계약서 삭제 → 200 + `chat_sessions.contract_id` 가 NULL로 (SET NULL 동작)