### PR TITLE
fix: User 모델에 profile_image_path 컬럼 정의 추가

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -9,6 +9,7 @@ class User(Base):
     email = Column(String(255), unique=True, nullable=False, index=True)
     nickname = Column(String(100), nullable=False)
     password_hash = Column(String(255), nullable=True)
+    profile_image_path = Column(String(500), nullable=True)
     email_verified_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, server_default=func.now())
     marketing_agreed = Column(Boolean, nullable=False, default=False, server_default="0")


### PR DESCRIPTION
Closes #49

## Summary
- User 모델에 `profile_image_path = Column(String(500), nullable=True)` 한 줄 추가
- 코드(`auth_service.profile_image_url` 등)가 ORM 속성으로 이미 쓰고 있는데 모델에 정의가 빠져있던 누락 버그 수정
- **DB 변경 없음** — 운영 DB엔 PR #41 시점에 이미 컬럼이 추가되어 있음. 모델만 맞춰주는 작업이라 Alembic 마이그레이션 불필요

## 팀원 동기화 방법
DB 손댈 것 없습니다. **`git pull` 만** 하면 됩니다.

만약 본인 로컬 DB에 컬럼이 없는 경우(컬럼 없는 상태에서 init_db()로만 DB를 만든 사람)에는, 서버를 한 번 재시작하면 lifespan의 `init_db()`가 컬럼을 자동 생성합니다.

## Test plan
- [x] 모델 매핑 확인: `User.__table__.columns['profile_image_path']` 존재 + `VARCHAR(500), nullable=True`
- [x] 실제 코드 경로 호출: `profile_image_url(user)` 정상 동작 (None 사용자에 대해 None 반환)
- [x] Alembic autogenerate diff에서 `profile_image_path` 관련 항목 사라짐 확인 (19 → 18)
- [ ] 머지 후 프론트엔드에서 프로필 이미지 업로드/조회 동작 확인

## 관련 후속 작업 (별도, 이 PR엔 미포함)
점검 중 모델 ↔ DB drift 17건 추가 발견:
- `qa_logs` 테이블 잔재 (모델/코드 0건 사용)
- `contracts.contract_type` nullable 불일치 (모델: NOT NULL, DB: NULL 허용)
- 컬럼 코멘트 15건 (DB에만 존재)

모두 **기능 영향 없음**이라 이 PR엔 포함하지 않음. 별도 정리 작업으로 처리.