### PR TITLE
fix: 이메일 인증 코드 발송 실패 시 CORS 에러로 오인되는 문제 수정

### DIFF
--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -254,15 +254,21 @@ async def request_email_verification(email: str, db: Session) -> None:
         db.add(record)
     db.commit()
 
-    await send_email(
-        to=email,
-        subject="[CLAIR] 이메일 인증 코드",
-        template="email_verification.html",
-        context={
-            "code": code,
-            "expire_minutes": settings.email_verification_code_expire_minutes,
-        },
-    )
+    try:
+        await send_email(
+            to=email,
+            subject="[CLAIR] 이메일 인증 코드",
+            template="email_verification.html",
+            context={
+                "code": code,
+                "expire_minutes": settings.email_verification_code_expire_minutes,
+            },
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"이메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요. ({type(e).__name__})",
+        )
 
 
 def confirm_email_verification(email: str, code: str, db: Session) -> None:


### PR DESCRIPTION
## 문제

이메일 인증 코드 요청(`POST /api/v1/auth/email-verification/request`) 시 프론트엔드에서 **CORS 에러**가 표시되며 요청이 실패했다.

## 원인

두 가지 문제가 겹쳐 발생:

1. **SMTP 미설정** — `.env`의 `SMTP_USER`, `SMTP_PASSWORD`가 비어 있어 `send_email()` 호출 시 연결 예외 발생
2. **미처리 예외의 CORS 헤더 누락** — `send_email()`의 예외가 `HTTPException`으로 감싸지지 않아 Starlette `ServerErrorMiddleware`가 `CORSMiddleware` 상위에서 가로채면서 `Access-Control-Allow-Origin` 헤더가 붙지 않은 plain text `500` 반환 → 브라우저는 실제 SMTP 오류가 아닌 CORS 에러로 오인

### Starlette 미들웨어 스택

```
ServerErrorMiddleware   ← 미처리 예외를 여기서 가로채 CORS를 우회
  └── CORSMiddleware
        └── ExceptionMiddleware  ← HTTPException은 여기서 JSON 변환
              └── Router
```

## 수정

- `request_email_verification()` 내 `send_email()` 호출을 `try-except`로 감싸 `HTTPException(503)`으로 변환
- 이후 SMTP 오류 발생 시 CORS 헤더가 정상 추가된 JSON 에러 응답 반환

```python
# 변경 전
await send_email(to=email, ...)

# 변경 후
try:
    await send_email(to=email, ...)
except Exception as e:
    raise HTTPException(
        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
        detail=f"이메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요. ({type(e).__name__})",
    )
```

## 수정 파일

- `app/services/auth_service.py`

## 테스트

- SMTP 설정 후 인증 코드 요청 → 정상 발송 확인
- 향후 SMTP 오류 발생 시 브라우저에 CORS 에러 대신 `503` JSON 에러 표시 확인

Closed #55 