### PR TITLE
feat: 월급여 후처리 계산 및 AIExtractionResult 필드 동기화

### DIFF
--- a/app/integrations/ai_models.py
+++ b/app/integrations/ai_models.py
@@ -37,6 +37,11 @@ class AIExtractionResult(BaseModel):
     end_date: AIFieldValue          # 계약 종료일
     amount_text: AIFieldValue       # 금액 원문 ex) "5,000만원"
     amount_value: AIFieldValue      # 금액 숫자 ex) 50000000.0
+    hourly_wage: AIFieldValue = AIFieldValue()          # 시간급 (원 단위)
+    weekly_work_hours: AIFieldValue = AIFieldValue()    # 주당 실근로시간
+    weekly_work_days: AIFieldValue = AIFieldValue()     # 주당 근무일수
+    monthly_wage: AIFieldValue = AIFieldValue()         # 월급여 (명시 or 계산값)
+    monthly_wage_is_estimated: bool = False             # True면 추정값
 
 
 # 위험 조항 탐지 결과 1건

--- a/app/services/contract_service.py
+++ b/app/services/contract_service.py
@@ -278,6 +278,20 @@ async def analyze_contract_background(contract_id: int) -> None:
         clause_rows = ai_clauses_to_contract_clauses(ai_resp.clauses, contract_id)
         db.add_all(clause_rows)
 
+        # 월급여 후처리: AI가 계산하지 못한 경우 백엔드에서 시간급 × 근무시간으로 계산
+        extraction = ai_resp.extraction
+        if extraction.monthly_wage.value is None:
+            try:
+                hw = float(extraction.hourly_wage.value) if extraction.hourly_wage.value else None
+                wwh = float(extraction.weekly_work_hours.value) if extraction.weekly_work_hours.value else None
+                if hw and wwh:
+                    weekly_holiday = (wwh / 40) * 8 if wwh >= 15 else 0
+                    estimated = round(hw * (wwh + weekly_holiday) * (365 / 12 / 7))
+                    extraction.monthly_wage = type(extraction.monthly_wage)(value=estimated)
+                    extraction.monthly_wage_is_estimated = True
+            except (TypeError, ValueError):
+                pass
+
         # 분석 결과 저장
         analysis = ai_analysis_to_analysis_result(ai_resp, contract_id, duration_seconds=duration)
         db.add(analysis)


### PR DESCRIPTION
## 개요

clair-ai의 신규 급여 계산 필드를 백엔드에 동기화하고, AI가 `monthly_wage`를 반환하지 못한 경우 백엔드에서 직접 계산하는 폴백을 추가했습니다.

## 변경 사항

### `app/integrations/ai_models.py`
`AIExtractionResult`에 clair-ai 신규 필드 동기화:
- `hourly_wage`, `weekly_work_hours`, `weekly_work_days`
- `monthly_wage`, `monthly_wage_is_estimated`

### `app/services/contract_service.py`
`analyze_contract_background`에 월급여 후처리 추가:

```
AI 응답에 monthly_wage가 null인 경우
  → hourly_wage × (weekly_work_hours + 주휴수당시간) × 4.345 계산
  → monthly_wage_is_estimated = True 설정
```

## 우선순위 흐름

```
1순위: 계약서 명시 월급여 (AI 반환, is_estimated=false)
2순위: AI가 시간급으로 계산 (is_estimated=true)
3순위: 백엔드 후처리 계산 (is_estimated=true)  ← 이번 추가
```

## 수정 파일
- `app/integrations/ai_models.py`
- `app/services/contract_service.py`

Closes #57