### PR TITLE
fix: CORS origins에 127.0.0.1 추가 (macOS localhost IPv6 우회)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ JWT_ALGORITHM=HS256
 
 
 # === CORS (프론트엔드 origin 허용) ===
-CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173,http://127.0.0.1:3000
 
 
 # === clair-ai 마이크로서비스 (분석/채팅 테스트 시만 필요) ===

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     gemini_api_key: str = ""
     ai_service_url: str = "http://localhost:8001"
     ai_service_timeout: float = 120.0   # OCR+LLM 분석은 최대 2분 허용
-    cors_origins: str = "http://localhost:3000,http://localhost:5173"
+    cors_origins: str = "http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173,http://127.0.0.1:3000"
 
     google_client_id: str = ""
     google_client_secret: str = ""


### PR DESCRIPTION
## 문제

macOS에서 `localhost`가 IPv6(`::1`)로 resolve되는 경우 프론트가 `http://127.0.0.1:5173`으로 접속하면 CORS 허용 목록에 없어 API 요청이 차단됨.

## 변경 사항

`app/core/config.py`와 `.env.example`의 `CORS_ORIGINS` 기본값에 `http://127.0.0.1:5173`, `http://127.0.0.1:3000` 추가.

```python
# 변경 전
cors_origins: str = "http://localhost:3000,http://localhost:5173"

# 변경 후
cors_origins: str = "http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173,http://127.0.0.1:3000"
```

## 적용하지 않은 방식

`allow_origins=["*"]` + `allow_credentials=False`는 JWT Bearer 토큰 인증이 깨지므로 사용하지 않음.

## 수정 파일

- `app/core/config.py`
- `.env.example`

Closes #58