### PR TITLE
fix: PDF 핵심 정보 key 라벨 한국어 변환

### DIFF
--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -35,13 +35,50 @@ from app.models.analysis import ContractClause
 
 
 _TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates" / "pdf"
+
+
+_RISK_LEVEL_LABELS = {"high": "높음", "medium": "보통", "low": "낮음"}
+
+# 핵심 정보 테이블의 key를 PDF 표시용 한국어 라벨로 변환 (표시용 — 원본 데이터/API 응답은 그대로 유지)
+KEY_INFO_LABELS = {
+    "start_date": "계약 시작일",
+    "end_date": "계약 종료일",
+    "signing_date": "계약 체결일",
+    "contract_type": "계약 유형",
+    "amount_text": "급여",
+    "amount_value": "급여 금액",
+    "hourly_wage": "시급",
+    "monthly_wage": "월급여",
+    "monthly_wage_is_estimated": "월급여 추정 여부",
+    "weekly_work_days": "주당 근무일",
+    "weekly_work_hours": "주당 근무시간",
+    "counterparty_a": "회사명",
+    "counterparty_b": "근로자명",
+}
+
+
+def format_key_info_label(key: str) -> str:
+    """핵심 정보 key를 한국어 라벨로 변환. 매핑이 없으면 원래 key를 그대로 반환."""
+    return KEY_INFO_LABELS.get(key, key)
+
+
+def format_pdf_value(value) -> str:
+    """PDF 표시용 값 포맷팅: None은 '-', boolean은 예/아니오."""
+    if value is None:
+        return "-"
+    if value is True:
+        return "예"
+    if value is False:
+        return "아니오"
+    return str(value)
+
+
 _jinja_env = Environment(
     loader=FileSystemLoader(_TEMPLATE_DIR),
     autoescape=select_autoescape(["html"]),
 )
-
-
-_RISK_LEVEL_LABELS = {"high": "높음", "medium": "보통", "low": "낮음"}
+_jinja_env.filters["key_info_label"] = format_key_info_label
+_jinja_env.filters["pdf_value"] = format_pdf_value
 
 
 def generate_contract_pdf(contract_id: int, user_id: int, db: Session) -> tuple[bytes, str]:

--- a/app/templates/pdf/contract_report.html
+++ b/app/templates/pdf/contract_report.html
@@ -94,13 +94,13 @@
     <table class="kv">
       {% for key, val in key_info.items() %}
         <tr>
-          <td class="k">{{ key }}</td>
+          <td class="k">{{ key | key_info_label }}</td>
           <td class="v">
             {% if val is mapping %}
-              {{ val.get('value', '-') }}
+              {{ val.get('value') | pdf_value }}
               {% if val.get('reason') %}<br><span class="meta">근거: {{ val.get('reason') }}</span>{% endif %}
             {% else %}
-              {{ val if val is not none else '-' }}
+              {{ val | pdf_value }}
             {% endif %}
           </td>
         </tr>


### PR DESCRIPTION
## 개요

분석 결과 PDF 다운로드에서 '핵심 정보' 섹션의 key 라벨이 영어(`end_date`, `start_date`, `amount_text`, `monthly_wage` 등)로 그대로 노출되던 문제를 수정합니다.

Closes #60

## 변경 사항

- `app/services/pdf_service.py`
  - `KEY_INFO_LABELS` 매핑 추가 (key → 한국어 라벨)
  - `format_key_info_label()` — 매핑에 없는 key는 원본 그대로 반환(신규 필드 안전)
  - `format_pdf_value()` — `None → -`, `True → 예`, `False → 아니오`
  - 위 두 함수를 Jinja 필터(`key_info_label`, `pdf_value`)로 등록
- `app/templates/pdf/contract_report.html`
  - 핵심 정보 테이블에서 key는 `| key_info_label`, 값은 `| pdf_value` 적용
  - `{value, reason}` 형태(mapping) 값도 동일하게 `pdf_value` 적용

## 영향 범위

- 원본 데이터 구조 / API 응답 구조 **변경 없음** — PDF 표시용 라벨만 변경
- 기존 PDF 다운로드 엔드포인트 **유지**

## 기대 결과

| key | 표시 |
|---|---|
| `end_date` | 계약 종료일 |
| `start_date` | 계약 시작일 |
| `amount_text` | 급여 |
| `weekly_work_hours` | 주당 근무시간 |
| `monthly_wage_is_estimated` (False) | 월급여 추정 여부 / 아니오 |