### PR TITLE
feat: 프로필 이미지 webp 허용 및 수정(PATCH)/삭제(DELETE) API 보강

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -17,7 +17,7 @@ from app.schemas.auth import (
 from app.schemas.contract import MessageResponse
 from app.services.auth_service import (
     signup, login, refresh_access_token, update_nickname, change_password,
-    update_profile_image, profile_image_url,
+    update_profile_image, delete_profile_image, profile_image_url,
     request_password_reset, verify_reset_token, confirm_password_reset,
     request_email_verification, confirm_email_verification,
     get_google_auth_url, google_login,
@@ -78,13 +78,23 @@ def api_change_password(body: ChangePasswordRequest, user: User = Depends(get_cu
     return MessageResponse(message="비밀번호가 변경되었습니다.")
 
 
-@router.post("/me/profile-image", response_model=MyInfoResponse, summary="프로필 이미지 업로드")
+@router.api_route(
+    "/me/profile-image",
+    methods=["POST", "PATCH"],
+    response_model=MyInfoResponse,
+    summary="프로필 이미지 업로드/수정",
+)
 async def api_upload_profile_image(
-    file: UploadFile = File(..., description="프로필 이미지 (PNG/JPG/JPEG, 최대 5MB)"),
+    file: UploadFile = File(..., description="프로필 이미지 (PNG/JPG/JPEG/WEBP, 최대 5MB)"),
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     return _to_my_info(await update_profile_image(user=user, file=file, db=db))
+
+
+@router.delete("/me/profile-image", response_model=MyInfoResponse, summary="프로필 이미지 삭제")
+def api_delete_profile_image(user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    return _to_my_info(delete_profile_image(user=user, db=db))
 
 
 # ── 비밀번호 재설정 (비로그인 상태에서 이메일 링크로) ─────────────────────────

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
 
     backend_base_url: str = "http://localhost:8000"
     profile_image_max_size_mb: int = 5
-    profile_image_allowed_extensions: str = ".png,.jpg,.jpeg"
+    profile_image_allowed_extensions: str = ".png,.jpg,.jpeg,.webp"
 
     secret_key: str = "change-this-to-random-secret-key"
     access_token_expire_minutes: int = 60

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -139,6 +139,26 @@ async def update_profile_image(user: User, file: UploadFile, db: Session) -> Use
     return user
 
 
+def delete_profile_image(user: User, db: Session) -> User:
+    """본인 프로필 이미지 삭제. 저장된 파일을 제거하고 경로를 비운다. 이미지가 없으면 그대로 반환."""
+    old_relative = user.profile_image_path
+    if not old_relative:
+        return user
+
+    user.profile_image_path = None
+    db.commit()
+    db.refresh(user)
+
+    old_path = Path(settings.upload_dir) / old_relative
+    try:
+        if old_path.is_file():
+            old_path.unlink()
+    except OSError:
+        pass
+
+    return user
+
+
 def change_password(user: User, current_password: str, new_password: str, db: Session) -> None:
     if not user.password_hash:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="소셜 로그인 계정은 비밀번호를 변경할 수 없습니다.")


### PR DESCRIPTION
## 개요

프로필 이미지 저장/조회 기능은 이미 구현되어 정상 동작 중입니다(실서버 엔드투엔드 확인 완료). 이 PR은 프론트 요구사항 대비 누락돼 있던 **webp 허용 / 삭제 / PATCH** 만 보강합니다.

Closes #62

## 변경 사항

- `app/core/config.py` — 허용 확장자에 `.webp` 추가 (`.png,.jpg,.jpeg,.webp`)
- `app/services/auth_service.py` — `delete_profile_image()` 추가: 저장 파일 삭제 + `profile_image_path` 비움
- `app/api/v1/auth.py`
  - 업로드 엔드포인트를 `POST`/`PATCH` 모두 처리하도록 통합 (`api_route`)
  - `DELETE /me/profile-image` 라우트 추가

## 엔드포인트

| Method | Path | 설명 |
|---|---|---|
| GET | `/api/v1/auth/me` | 응답에 `profile_image` URL 포함 (기존) |
| POST / PATCH | `/api/v1/auth/me/profile-image` | 업로드/수정 (multipart `file`) |
| DELETE | `/api/v1/auth/me/profile-image` | 삭제 |

## 검증 (실서버, user 7)

- `GET /me` → `profile_image` URL 정상 반환
- 정적 이미지 서빙 → `HTTP 200, image/png`
- `.gif` 업로드 → `HTTP 400 지원하지 않는 이미지 형식` (허용 목록에 `.webp` 노출 확인)
- 미인증 `DELETE` → `HTTP 401`

## 영향 범위

- 기존 데이터 구조 / `/me` 응답 구조 / 로그인·회원가입 흐름 **변경 없음**
- 인증된 사용자만 본인 이미지 수정/삭제, 5MB 크기 제한 유지