### PR TITLE
feat: 채팅 세션 응답에 계약서 연결 정보 추가 및 최신순 정렬

### DIFF
--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
@@ -12,6 +13,21 @@ from app.services.chat_service import create_session, get_session_by_id, get_ses
 router = APIRouter()
 
 
+def _contract_summary(contract) -> Optional[dict]:
+    """연결된 계약서를 프론트가 쓰기 쉬운 요약 dict로. 미연결(또는 계약서 삭제)이면 None."""
+    if contract is None:
+        return None
+    name = contract.original_filename
+    return {
+        "id": contract.id,
+        "original_filename": name,
+        "file_name": name,
+        "title": name.rsplit(".", 1)[0] if name else None,
+        "contract_type": contract.contract_type.value if contract.contract_type else None,
+        "status": contract.status.value if contract.status else None,
+    }
+
+
 def _session_to_response_dict(session) -> dict:
     return {
         "id": session.id,
@@ -21,6 +37,7 @@ def _session_to_response_dict(session) -> dict:
         "last_message_at": session.last_message_at,
         "created_at": session.created_at,
         "updated_at": session.updated_at,
+        "contract": _contract_summary(session.contract),
     }
 
 

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -8,6 +8,16 @@ class ChatSessionCreateRequest(BaseModel):
     title: Optional[str] = "새 대화"
 
 
+class ContractSummary(BaseModel):
+    # 채팅 세션에 연결된 계약서 요약 — 프론트 호환을 위해 파일명을 여러 키로 함께 제공
+    id: int
+    original_filename: Optional[str] = None
+    file_name: Optional[str] = None
+    title: Optional[str] = None
+    contract_type: Optional[str] = None
+    status: Optional[str] = None
+
+
 class ChatSessionResponse(BaseModel):
     id: int
     contract_id: Optional[int] = None
@@ -16,6 +26,8 @@ class ChatSessionResponse(BaseModel):
     last_message_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
+    # 계약서 연결 세션이면 채워지고, 일반 상담 세션이면 None
+    contract: Optional[ContractSummary] = None
     model_config = {"from_attributes": True}
 
 

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from fastapi import HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func
 from app.models.chat import ChatSession, ChatMessage, MessageSender, MessageType
 from app.models.contract import Contract, ContractStatus
@@ -41,7 +41,20 @@ def get_session_by_id(session_id: int, user_id: int, db: Session) -> ChatSession
 def get_sessions_by_user(user_id: int, db: Session, skip: int = 0, limit: int = 20):
     query = db.query(ChatSession).filter(ChatSession.user_id == user_id)
     total = query.count()
-    sessions = query.order_by(ChatSession.updated_at.desc()).offset(skip).limit(limit).all()
+    # 최신 대화 우선: last_message_at desc > updated_at desc > created_at desc.
+    # (MySQL은 DESC 정렬에서 NULL을 마지막에 두므로 대화 없는 세션이 하단으로 내려감)
+    # joinedload(contract): 목록 응답의 계약서 요약을 N+1 없이 함께 로드
+    sessions = (
+        query.options(joinedload(ChatSession.contract))
+        .order_by(
+            ChatSession.last_message_at.desc(),
+            ChatSession.updated_at.desc(),
+            ChatSession.created_at.desc(),
+        )
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
     return total, sessions
 
 


### PR DESCRIPTION
Closes #68

## 개요

세션 이력 화면에서 계약서 연결 세션을 정확히 표시할 수 있도록 채팅 세션 목록/상세 응답을 보강합니다. 기존 필드는 유지하고 optional 필드만 추가했습니다.

## 변경 사항

- `app/schemas/chat.py`
  - `ContractSummary` 모델 추가
  - `ChatSessionResponse`에 optional `contract` 필드 추가 → 목록(`ChatSessionListItem` 상속)·상세 모두 동일하게 내려감
- `app/api/v1/chat.py`
  - `_contract_summary()`로 연결 계약서를 요약 dict로 변환 (`original_filename`/`file_name`/`title`/`contract_type`/`status`)
  - 일반 상담 세션이면 `contract: null`
- `app/services/chat_service.py`
  - 목록 정렬: `last_message_at desc > updated_at desc > created_at desc`
  - `joinedload(contract)`로 N+1 방지

## 요구사항 충족

| # | 요구사항 | 처리 |
|---|---|---|
| 1,2 | 목록/상세에 계약서 연결 정보 | `contract` 객체 추가 |
| 3 | 기존 필드 유지, optional만 추가 | ✅ |
| 4 | 연결 세션은 contract_id + 파일명/제목 | `contract.{original_filename,file_name,title}` |
| 5 | 일반 세션은 contract_id null | `contract: null` |
| 6 | 최신순 정렬 | last_message_at→updated_at→created_at desc |
| 7,8 | 메시지 생성 시 last_message_at 갱신 | 기존 `_bump_session_counters`가 메시지마다 갱신 (변경 불필요) |
| 9 | 파일명 키 호환 | `original_filename`/`file_name`/`title` 동시 제공 |

## 검증 (실서버)

- 계약서 연결 세션: 목록·상세 모두 `contract` 객체 포함 (`employment`/`completed` 등)
- 임시 일반 세션 생성 → `contract: null` 확인 후 삭제
- 정렬: `last_message_at` 최신 세션이 상단