### PR TITLE
fix: 분석 미완료 시 이전 분석 결과가 상세 응답에 새는 문제 수정

### DIFF
--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -5,6 +5,7 @@ from urllib.parse import quote
 from app.db.session import get_db
 from app.core.security import get_current_user
 from app.models.user import User
+from app.models.contract import ContractStatus
 from app.schemas.contract import (
     ContractUploadResponse, ContractDetailResponse, ContractListResponse, ContractListItem,
     AnalysisResultResponse, RiskClauseResponse, MessageResponse,
@@ -71,39 +72,52 @@ def api_list_contracts(skip: int = Query(0, ge=0), limit: int = Query(20, ge=1, 
 @router.get("/{contract_id}", response_model=ContractDetailResponse, summary="계약서 상세 조회")
 def api_get_contract(contract_id: int, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     contract = get_contract_by_id(contract_id, user.id, db)
+
+    # 분석 완료(COMPLETED) 상태에서만 분석 결과를 노출한다.
+    # 재분석 중에는 이전 분석 행이 DB에 남아 있으므로(새 결과가 준비될 때까지 보존),
+    # 상태로 게이팅하지 않으면 PENDING/PROCESSING/FAILED 중에도 예전 결과가 내려가
+    # 프론트 로딩 화면이 완료로 오판하고 직전 계약서 결과를 보여주는 문제가 생긴다.
     analysis = None
-    if contract.analysis_result:
-        analysis = AnalysisResultResponse(key_info=contract.analysis_result.key_info, clauses=contract.analysis_result.clauses,
-                                          summary=contract.analysis_result.summary, detected_objects=contract.analysis_result.detected_objects,
-                                          created_at=contract.analysis_result.created_at)
-    risk_clauses = None
-    if contract.risk_clauses:
+    risk_clauses: list = []
+    clauses = None
+    compliance_results: list = []
+    safety_score = None
+    score_detail = None
+
+    if contract.status == ContractStatus.COMPLETED:
+        if contract.analysis_result:
+            analysis = AnalysisResultResponse(key_info=contract.analysis_result.key_info, clauses=contract.analysis_result.clauses,
+                                              summary=contract.analysis_result.summary, detected_objects=contract.analysis_result.detected_objects,
+                                              created_at=contract.analysis_result.created_at)
         risk_clauses = [RiskClauseResponse(id=rc.id, title=rc.title, clause_number=rc.clause_number,
                                            original_text=rc.original_text, risk_type=rc.risk_type,
                                            risk_level=rc.risk_level.value, severity_score=rc.severity_score,
                                            confidence=rc.confidence, explanation=rc.explanation,
                                            problematic_text=rc.problematic_text,
                                            evidence_clause_ids=rc.evidence_clause_ids, evidence_text=rc.evidence_text)
-                        for rc in contract.risk_clauses]
-    clauses = [
-        ClauseResponse(id=c.id, clause_id=c.clause_id, title=c.title, text=c.text,
-                       page_refs=c.page_refs, order=c.order)
-        for c in (contract.clauses or [])
-    ] or None
-    compliance_results = [
-        ComplianceResultResponse(id=cr.id, clause_id=cr.clause_id, clause_title=cr.clause_title,
-                                 clause_text=cr.clause_text, status=cr.status, reason=cr.reason,
-                                 law_references=cr.law_references)
-        for cr in (contract.compliance_results or [])
-    ] or None
-    score_detail = compute_safety_score(contract.risk_clauses or [])
+                        for rc in (contract.risk_clauses or [])]
+        clauses = [
+            ClauseResponse(id=c.id, clause_id=c.clause_id, title=c.title, text=c.text,
+                           page_refs=c.page_refs, order=c.order)
+            for c in (contract.clauses or [])
+        ] or None
+        compliance_results = [
+            ComplianceResultResponse(id=cr.id, clause_id=cr.clause_id, clause_title=cr.clause_title,
+                                     clause_text=cr.clause_text, status=cr.status, reason=cr.reason,
+                                     law_references=cr.law_references)
+            for cr in (contract.compliance_results or [])
+        ]
+        score_detail = compute_safety_score(contract.risk_clauses or [])
+        safety_score = score_detail["score"]
+
     return ContractDetailResponse(id=contract.id, original_filename=contract.original_filename, file_size=contract.file_size,
-                                  file_type=contract.file_type, status=contract.status.value, contract_type=contract.contract_type.value,
+                                  file_type=contract.file_type, status=contract.status.value,
+                                  analysis_status=contract.status.value, contract_type=contract.contract_type.value,
                                   extracted_text=contract.extracted_text, created_at=contract.created_at, updated_at=contract.updated_at,
                                   analysis_completed_at=contract.analysis_completed_at,
                                   analysis=analysis, risk_clauses=risk_clauses,
                                   clauses=clauses, compliance_results=compliance_results,
-                                  safety_score=score_detail["score"],
+                                  safety_score=safety_score,
                                   safety_score_detail=score_detail)
 
 

--- a/app/schemas/contract.py
+++ b/app/schemas/contract.py
@@ -20,6 +20,9 @@ class ContractDetailResponse(BaseModel):
     file_size: int
     file_type: str
     status: str
+    # status와 동일한 분석 생애주기 값(uploaded/pending/processing/completed/failed).
+    # 프론트가 분석 완료 판단에 사용 — analysis 페이로드와 항상 일관되게 내려간다.
+    analysis_status: str
     contract_type: str
     extracted_text: Optional[str] = None
     created_at: datetime


### PR DESCRIPTION
Closes #69

## 증상
계약서 관리 화면에서 B 계약서를 분석해도 결과 화면에 직전 A 계약서의 분석 결과가 계속 표시됨. (재분석 시에도 이전 결과가 노출됨)

## 진단
- **데이터 연결은 정상이었음**: 모든 분석 테이블(`analysis_results`/`risk_clauses`/`contract_clauses`/`compliance_results`)이 `contract_id` FK로 스코프되고, `analysis_results.contract_id`는 unique. `get_contract_by_id`는 `contract_id + user_id`로 조회. 전역 캐시/세션/공유 상태 없음. → 요구사항 1,2,5,8,9 구조적으로 OK.
- **실제 버그는 응답 조립 계층**: `GET /contracts/{id}`가 `analysis_result` 행이 **존재하기만 하면 status와 무관하게** `analysis`/`risk_clauses`/`compliance_results`를 반환. 재분석 시 이전 분석 행은 새 결과가 준비될 때까지 DB에 보존되므로(분석 실패 대비 resilience), PENDING/PROCESSING/FAILED 중에도 예전 결과가 내려가 프론트 로딩 화면이 완료로 오판 → 직전 결과 표시.
- 응답에 `analysis_status` 필드도 없었음(프론트/요구사항 7이 기대).

## 수정
- `status == COMPLETED`일 때만 분석 페이로드를 노출하도록 **상태 게이팅**.
- 미완료 상태에서는 `analysis: null`, `risk_clauses: []`, `compliance_results: []`, `safety_score: null` 반환 → 요구사항의 "분석 중 응답 예시"와 정확히 일치.
- `ContractDetailResponse`에 `analysis_status`(= status 값) 추가.
- 데이터 모델/관계/삭제 로직은 변경 없음(이전 행을 새 결과 준비 전까지 보존하는 동작 유지).

## 검증 (실서버)
| 케이스 | status | analysis | risk_clauses | safety_score |
|---|---|---|---|---|
| 완료(28) | completed | OBJ | [...] | 95 |
| 업로드(27) | uploaded | null | [] | null |
| 실패(24) | failed | null | [] | null |
| **28을 일시 processing(분석행 보존)** | processing | **null** | **[]** | **null** |
| 28 복구 | completed | OBJ | [...] | 95 |

→ 분석 행이 DB에 남아있어도 비완료 상태면 예전 결과가 절대 새지 않음을 확인. (테스트 후 데이터 원복)