### PR TITLE
feat: 계약서 목록 응답에 safety_score 추가 (홈 계약 안정도 평균)

### DIFF
--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -63,8 +63,13 @@ def api_list_contracts(skip: int = Query(0, ge=0), limit: int = Query(20, ge=1, 
                        user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     total, contracts = get_contracts_by_user(user_id=user.id, db=db, skip=skip, limit=limit)
     return ContractListResponse(total=total, contracts=[
-        ContractListItem(id=c.id, original_filename=c.original_filename, file_type=c.file_type,
-                         status=c.status.value, contract_type=c.contract_type.value, created_at=c.created_at)
+        ContractListItem(
+            id=c.id, original_filename=c.original_filename, file_type=c.file_type,
+            status=c.status.value, analysis_status=c.status.value, contract_type=c.contract_type.value,
+            # 분석 완료 계약서만 안전점수 노출 — 상세 API와 동일하게 compute_safety_score 사용
+            safety_score=(compute_safety_score(c.risk_clauses or [])["score"]
+                          if c.status.value == "completed" else None),
+            created_at=c.created_at, updated_at=c.updated_at)
         for c in contracts])
 
 

--- a/app/schemas/contract.py
+++ b/app/schemas/contract.py
@@ -39,8 +39,14 @@ class ContractListItem(BaseModel):
     original_filename: str
     file_type: str
     status: str
+    # status와 동일한 분석 생애주기 값 — 프론트 분석 완료 판단용
+    analysis_status: str
     contract_type: str
+    # 분석 완료(COMPLETED) 계약서만 0~100 정수, 그 외에는 null.
+    # 상세 API(GET /contracts/{id})의 safety_score와 동일 기준(compute_safety_score)
+    safety_score: Optional[int] = None
     created_at: datetime
+    updated_at: datetime
     model_config = {"from_attributes": True}
 
 

--- a/app/services/contract_service.py
+++ b/app/services/contract_service.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from pathlib import Path
 from PIL import Image, ImageOps
 from fastapi import UploadFile, HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from app.core.config import settings
 from app.db.session import SessionLocal
 from app.models.contract import Contract, ContractStatus
@@ -198,7 +198,14 @@ def get_contract_by_id(contract_id: int, user_id: int, db: Session) -> Contract:
 def get_contracts_by_user(user_id: int, db: Session, skip: int = 0, limit: int = 20):
     query = db.query(Contract).filter(Contract.user_id == user_id)
     total = query.count()
-    contracts = query.order_by(Contract.created_at.desc()).offset(skip).limit(limit).all()
+    # safety_score 계산을 위해 risk_clauses를 함께 로드 — 목록 N+1 방지
+    contracts = (
+        query.options(selectinload(Contract.risk_clauses))
+        .order_by(Contract.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
     return total, contracts
 
 


### PR DESCRIPTION
Closes #70

## 개요
홈 화면의 '계약 안정도' 평균을 분석 완료 계약서들의 실제 안전점수 평균으로 계산할 수 있도록 `GET /api/v1/contracts/` 목록 응답을 보강합니다. 기존 필드는 유지하고 optional 필드만 추가.

## 변경 사항
- `app/schemas/contract.py` — `ContractListItem`에 `safety_score`(Optional[int]), `analysis_status`, `updated_at` 추가
- `app/api/v1/contracts.py` — 목록 항목에 safety_score 계산. **분석 완료(COMPLETED)일 때만** `compute_safety_score(risk_clauses)["score"]`, 그 외 `null`
- `app/services/contract_service.py` — 목록 조회 시 `selectinload(Contract.risk_clauses)`로 N+1 방지

## 요구사항 충족
| # | 요구사항 | 처리 |
|---|---|---|
| 1,2 | 최상위 safety_score | 추가 |
| 3 | 완료 계약서만 숫자 | COMPLETED 게이팅 |
| 4 | 미완료는 null | uploaded/processing/failed → null |
| 5 | 0~100 | compute_safety_score(최소 25~100) |
| 6 | 상세와 동일 기준 | 동일하게 compute_safety_score 사용 |
| 7 | contract_id 정확 연결 | risk_clauses가 contract_id FK로 스코프 |
| 8 | 기존 필드 유지 | optional만 추가 |
| 9 | analysis_status 일관 | status와 동일 값 제공 |

## 검증 (실서버)
- 목록: id=28 completed→`95`, uploaded/failed→`null`
- 교차검증: 상세 id=28 `safety_score=95` = 목록 `95` (동일 기준)
- N+1 없음: risk_clauses를 `IN (...)` 단일 쿼리로 로드

> 참고: 상세 API의 미완료 시 게이팅은 별도 PR #66에서 다룹니다. 본 PR의 목록 safety_score는 #66과 독립적으로 동작하며, 두 곳 모두 `compute_safety_score` 동일 기준을 사용합니다.