### PR TITLE
feat: PDF 보고서 영문 key/type 한글 라벨 변환

### DIFF
--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -44,22 +44,61 @@ KEY_INFO_LABELS = {
     "start_date": "계약 시작일",
     "end_date": "계약 종료일",
     "signing_date": "계약 체결일",
-    "contract_type": "계약 유형",
+    "contract_type": "계약서 유형",
     "amount_text": "급여",
     "amount_value": "급여 금액",
     "hourly_wage": "시급",
-    "monthly_wage": "월급여",
-    "monthly_wage_is_estimated": "월급여 추정 여부",
+    "monthly_wage": "월 급여",
+    "monthly_wage_is_estimated": "월 급여 추정 여부",
     "weekly_work_days": "주당 근무일",
     "weekly_work_hours": "주당 근무시간",
-    "counterparty_a": "회사명",
-    "counterparty_b": "근로자명",
+    "counterparty_a": "당사자 A",
+    "counterparty_b": "당사자 B",
+}
+
+# 위험 유형(risk_type)을 PDF 표시용 한국어로 변환
+RISK_TYPE_LABELS = {
+    "payment": "지급/급여",
+    "liability": "책임",
+    "termination": "해지",
+    "confidentiality": "비밀유지",
+    "penalty": "위약금",
+    "renewal": "갱신",
+    "ip": "지식재산권",
+    "etc": "기타",
+    "other": "기타",
+}
+
+# 계약서 유형(ContractType enum)을 PDF 표시용 한국어로 변환
+CONTRACT_TYPE_LABELS = {
+    "labor": "근로계약서",
+    "employment": "근로계약서",
+    "service": "용역계약서",
+    "freelance": "프리랜서 계약서",
+    "nda": "비밀유지계약서",
+    "company_rule": "취업규칙",
+    "other": "기타",
+    "unknown": "미분류",
 }
 
 
 def format_key_info_label(key: str) -> str:
     """핵심 정보 key를 한국어 라벨로 변환. 매핑이 없으면 원래 key를 그대로 반환."""
     return KEY_INFO_LABELS.get(key, key)
+
+
+def format_risk_type(risk_type) -> str:
+    """위험 유형을 한국어로 변환. 매핑이 없으면 원래 값을 그대로 반환."""
+    if risk_type is None:
+        return "-"
+    return RISK_TYPE_LABELS.get(str(risk_type).lower(), str(risk_type))
+
+
+def format_contract_type(contract_type) -> str:
+    """계약서 유형 enum 값을 한국어로 변환. 매핑이 없으면 원래 값을 그대로 반환."""
+    if contract_type is None:
+        return "-"
+    return CONTRACT_TYPE_LABELS.get(str(contract_type).lower(), str(contract_type))
 
 
 def format_pdf_value(value) -> str:
@@ -78,6 +117,8 @@ _jinja_env = Environment(
     autoescape=select_autoescape(["html"]),
 )
 _jinja_env.filters["key_info_label"] = format_key_info_label
+_jinja_env.filters["risk_type_label"] = format_risk_type
+_jinja_env.filters["contract_type_label"] = format_contract_type
 _jinja_env.filters["pdf_value"] = format_pdf_value
 
 

--- a/app/templates/pdf/contract_report.html
+++ b/app/templates/pdf/contract_report.html
@@ -80,7 +80,7 @@
   <div class="header">
     <h1>{{ original_filename }}</h1>
     <div class="meta">
-      <span class="label label-contract-type">{{ contract_type }}</span>
+      <span class="label label-contract-type">{{ contract_type | contract_type_label }}</span>
       &nbsp;
       분석일: {{ analyzed_at.strftime('%Y-%m-%d %H:%M') if analyzed_at else '-' }}
       &nbsp;·&nbsp;
@@ -125,7 +125,7 @@
       <div class="risk-card risk-{{ r.risk_level }}">
         <div class="risk-meta">
           <span class="risk-badge badge-{{ r.risk_level }}">위험도 {{ r.risk_level_label }}</span>
-          <strong>{{ r.risk_type }}</strong>
+          <strong>{{ r.risk_type | risk_type_label }}</strong>
           {% if r.clause_number %}&nbsp;·&nbsp;{{ r.clause_number }}{% endif %}
         </div>
         {% if r.explanation %}


### PR DESCRIPTION
Closes #72

## 개요
PDF 다운로드 보고서에 영문 key/type 값이 그대로 노출되던 문제를 수정합니다. 표시용 라벨만 변환하며 원본 데이터·API 응답·다운로드 경로는 변경하지 않습니다.

## 변경
- `app/services/pdf_service.py`
  - `RISK_TYPE_LABELS` + `format_risk_type` 추가 (payment→지급/급여, liability→책임, termination→해지, confidentiality→비밀유지, penalty→위약금, renewal→갱신, ip→지식재산권 등)
  - `CONTRACT_TYPE_LABELS` + `format_contract_type` 추가 (labor/employment→근로계약서, service→용역계약서, freelance→프리랜서 계약서, nda→비밀유지계약서, company_rule→취업규칙, other→기타, unknown→미분류)
  - `KEY_INFO_LABELS` 표기 보정: 계약서 유형 / 당사자 A·B / 월 급여
  - Jinja 필터 등록(`risk_type_label`, `contract_type_label`)
- `app/templates/pdf/contract_report.html`
  - 헤더 `contract_type` → `| contract_type_label`
  - 위험 조항 `risk_type` → `| risk_type_label`

## 검증 (실제 PDF 렌더링)
- 헤더 칩: `employment` → **근로계약서**
- 핵심 정보: **계약서 유형 / 당사자 A / 당사자 B / 월 급여**
- 필터 단위 검증: risk_type(payment→지급/급여, liability→책임 …), contract_type(service→용역계약서, nda→비밀유지계약서, unknown→미분류)
- 매핑에 없는 값은 원본 그대로 노출(신규 값 안전)