### PR TITLE
fix: 소셜 로그인 OAuth client_id 누락 및 콜백 프론트 리다이렉트 연결 (#74)

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -10,7 +10,6 @@ from app.schemas.auth import (
     LoginRequest, TokenResponse,
     RefreshRequest, RefreshResponse,
     MyInfoResponse, UpdateNicknameRequest, ChangePasswordRequest,
-    SocialLoginResponse,
     PasswordResetRequest, PasswordResetConfirmRequest, PasswordResetVerifyResponse,
     EmailVerificationRequest, EmailVerificationConfirmRequest,
 )
@@ -23,6 +22,7 @@ from app.services.auth_service import (
     get_google_auth_url, google_login,
     get_naver_auth_url, naver_login,
     get_kakao_auth_url, kakao_login,
+    social_callback_redirect_url,
 )
 
 router = APIRouter()
@@ -139,9 +139,10 @@ def api_google_login():
     return RedirectResponse(url=get_google_auth_url())
 
 
-@router.get("/google/callback", response_model=SocialLoginResponse, summary="구글 소셜 로그인 콜백")
+@router.get("/google/callback", summary="구글 소셜 로그인 콜백 (프론트로 리다이렉트)")
 def api_google_callback(code: str, db: Session = Depends(get_db)):
-    return google_login(code=code, db=db)
+    result = google_login(code=code, db=db)
+    return RedirectResponse(url=social_callback_redirect_url(result))
 
 
 # ── Naver ─────────────────────────────────────────────────────────────────────
@@ -151,9 +152,10 @@ def api_naver_login():
     return RedirectResponse(url=get_naver_auth_url())
 
 
-@router.get("/naver/callback", response_model=SocialLoginResponse, summary="네이버 소셜 로그인 콜백")
+@router.get("/naver/callback", summary="네이버 소셜 로그인 콜백 (프론트로 리다이렉트)")
 def api_naver_callback(code: str, state: str, db: Session = Depends(get_db)):
-    return naver_login(code=code, state=state, db=db)
+    result = naver_login(code=code, state=state, db=db)
+    return RedirectResponse(url=social_callback_redirect_url(result))
 
 
 # ── Kakao ─────────────────────────────────────────────────────────────────────
@@ -163,6 +165,7 @@ def api_kakao_login():
     return RedirectResponse(url=get_kakao_auth_url())
 
 
-@router.get("/kakao/callback", response_model=SocialLoginResponse, summary="카카오 소셜 로그인 콜백")
+@router.get("/kakao/callback", summary="카카오 소셜 로그인 콜백 (프론트로 리다이렉트)")
 def api_kakao_callback(code: str, db: Session = Depends(get_db)):
-    return kakao_login(code=code, db=db)
+    result = kakao_login(code=code, db=db)
+    return RedirectResponse(url=social_callback_redirect_url(result))

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,10 @@
+from pathlib import Path
 from pydantic_settings import BaseSettings
 from typing import List
+
+# 프로젝트 루트(.env 위치). uvicorn을 다른 작업 디렉터리에서 실행해도
+# .env 를 항상 찾도록 절대경로로 고정한다. config.py = app/core/config.py 이므로 parents[2] 가 루트.
+_ENV_FILE = str(Path(__file__).resolve().parents[2] / ".env")
 
 
 class Settings(BaseSettings):
@@ -50,6 +55,7 @@ class Settings(BaseSettings):
     mail_from_name: str = "CLAIR"
 
     frontend_base_url: str = "http://localhost:5173"
+    social_callback_path: str = "/social-callback"
     password_reset_path: str = "/password-reset"
     password_reset_token_expire_minutes: int = 30
 
@@ -84,7 +90,7 @@ class Settings(BaseSettings):
     def profile_image_max_size_bytes(self) -> int:
         return self.profile_image_max_size_mb * 1024 * 1024
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
+    model_config = {"env_file": _ENV_FILE, "env_file_encoding": "utf-8", "extra": "ignore"}
 
 
 settings = Settings()

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -379,6 +379,20 @@ def _social_login(provider: str, provider_id: str, email: str, nickname: str, db
     }
 
 
+def social_callback_redirect_url(result: dict) -> str:
+    """소셜 로그인 결과(JWT)를 프론트 콜백 페이지 쿼리스트링으로 전달하는 URL.
+
+    프론트는 /social-callback?token=...&refresh_token=... 형태를 기대한다.
+    """
+    params = {
+        "token": result["access_token"],
+        "refresh_token": result["refresh_token"],
+        "is_new_user": str(result.get("is_new_user", False)).lower(),
+    }
+    base = settings.frontend_base_url.rstrip("/")
+    return f"{base}{settings.social_callback_path}?{urlencode(params)}"
+
+
 # ── Google ────────────────────────────────────────────────────────────────────
 
 def get_google_auth_url() -> str:


### PR DESCRIPTION
Closes #74

## 배경
소셜 로그인 시 Google OAuth 화면에서 `Missing required parameter: client_id` (400 invalid_request) 오류 발생.

## 원인
1. `app/core/config.py`의 `env_file=".env"`가 **상대경로** → uvicorn을 레포 루트가 아닌 디렉터리에서 실행하면 `.env`를 못 찾아 `GOOGLE_CLIENT_ID` 등이 빈 문자열 → 인증 URL의 `client_id` 누락.
2. google/naver/kakao 콜백이 `SocialLoginResponse`(JSON)만 반환 → 프론트가 기대하는 `/social-callback?token=...&refresh_token=...` 리다이렉트로 연결 안 됨.

## 변경
- `env_file`을 config.py 위치 기준 **절대경로**로 고정 (작업 디렉터리 무관하게 `.env` 로드).
- 세 소셜 콜백을 프론트 `social_callback_path`(기본 `/social-callback`)로 `RedirectResponse`. 미사용 `SocialLoginResponse` import 정리.
- `social_callback_path` 설정 신규 추가.

## 검증
- 테스트 러너 없음 → import / URL 생성 / 실제 서버 리다이렉트 Location 헤더로 확인.
- `/api/v1/auth/google` Location에 `client_id` 정상 포함 확인.
- 콜백 리다이렉트 URL이 `http://localhost:5173/social-callback?token=...&refresh_token=...&is_new_user=...` 형식으로 생성됨 확인.

## 운영 체크 (코드 밖)
- 서버 재시작 필요.
- Google Console 승인 리디렉션 URI ↔ `.env`의 `*_REDIRECT_URI` 정확히 일치 (localhost ↔ 127.0.0.1 통일 권장).