### PR TITLE
feat: 분석 요청에 /request-analysis 호환용 별칭 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ alembic upgrade head
 | GET | `/{id}` | 계약서 상세 + 분석 결과 + safety_score |
 | DELETE | `/{id}` | 계약서 삭제 |
 | POST | `/{id}/analyze` | 분석 요청 (202 Accepted, 백그라운드 실행) |
+| POST | `/{id}/request-analysis` | `/analyze` 호환용 별칭 (동일 로직) |
 | GET | `/{id}/status` | 분석 상태 조회 |
 | GET | `/{id}/clauses` | 조항 목록 |
 | POST | `/{id}/share` | 공유 링크 생성 |

--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -132,7 +132,14 @@ def api_delete_contract(contract_id: int, user: User = Depends(get_current_user)
     return MessageResponse(message="계약서가 삭제되었습니다.")
 
 
+# 정식 엔드포인트는 /analyze. /request-analysis 는 하위 호환용 별칭 — 둘 다 동일 로직.
 @router.post("/{contract_id}/analyze", response_model=AnalyzeAcceptedResponse, status_code=202, summary="계약서 분석 요청")
+@router.post(
+    "/{contract_id}/request-analysis",
+    response_model=AnalyzeAcceptedResponse,
+    status_code=202,
+    summary="계약서 분석 요청 (호환용 — /analyze 사용 권장)",
+)
 async def api_request_analysis(
     contract_id: int,
     background_tasks: BackgroundTasks,


### PR DESCRIPTION
## Summary

프론트팀 요청 — 분석 요청 엔드포인트를 `/analyze`·`/request-analysis` 둘 다 지원.

- `POST /{id}/analyze` (정식, 기존 그대로) 와 `POST /{id}/request-analysis` (호환용 별칭)를 **같은 함수**에 데코레이터로 등록 → 동일 로직
- 두 경로 모두 `trigger_analysis` → `BackgroundTask` → `202 Accepted` + `poll_url=/api/v1/contracts/{id}/status`
- Swagger summary + README 표에 호환용으로 표기

> 참고: 확인해보니 현재 코드엔 이미 `/analyze`가 정식으로 있었고 `/request-analysis`는 없었음 (팀 파악과 반대). 그래서 `/request-analysis`를 별칭으로 **추가**하는 방향으로 처리.

## Related Issue

Closes #76

## Test plan

- [x] OpenAPI에 `/analyze`·`/request-analysis` 두 경로 노출 확인
- [x] 새 계약서에서 `/analyze` → 202
- [x] 새 계약서에서 `/request-analysis` → 202 + 동일 `poll_url`
- [x] 이미 PROCESSING이면 양쪽 다 409 (동일 가드 로직 공유 확인)