### PR TITLE
fix: PDF 보고서 금액 표시를 프론트 화면처럼 숫자만 정리

### DIFF
--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -13,6 +13,7 @@ WeasyPrint(HTML→PDF)를 사용해 Jinja2 템플릿으로 한국어 분석 보�
 """
 import os
 import platform
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -112,6 +113,47 @@ def format_pdf_value(value) -> str:
     return str(value)
 
 
+# 금액 표시 정리 대상 key_info 키 (표시용 — 원본 데이터/API 응답은 그대로 유지)
+MONEY_KEYS = {"amount_text", "amount_value", "hourly_wage", "monthly_wage"}
+
+# 천 단위 콤마를 포함할 수 있는 아라비아 숫자 토큰
+_MONEY_NUM_RE = re.compile(r"\d[\d,]*")
+# 숫자 바로 뒤에 붙는 한국어 단위(만/억/천/조) → 축약 표기로 간주
+_KO_UNIT_RE = re.compile(r"^\s*[만억천조]")
+
+
+def format_money(value) -> str:
+    """금액 값을 프론트 화면처럼 정리: 숫자만 추출해 천 단위 콤마 + '원'.
+
+    예) '금 450,000,000원 (사억오천만원 정)' → '450,000,000원'
+        '450,000,000원 사억오천만원정'       → '450,000,000원'
+        450000000                           → '450,000,000원'
+
+    숫자를 찾지 못하면 pdf_value 규칙으로 폴백하고, '5,000만원'처럼 한국어 단위
+    축약 표기면 잘못된 숫자로 바꾸지 않도록 원본 표현을 그대로 둔다.
+    """
+    if value is None:
+        return "-"
+    if isinstance(value, bool):
+        return format_pdf_value(value)
+    if isinstance(value, (int, float)):
+        num = int(value) if float(value).is_integer() else value
+        return f"{num:,}원"
+    text = str(value).strip()
+    if not text:
+        return "-"
+    m = _MONEY_NUM_RE.search(text)
+    if not m:
+        return format_pdf_value(value)
+    # 숫자 직후가 만/억/천/조 단위면 축약 표기 → 원본 유지 (예: '5,000만원')
+    if _KO_UNIT_RE.match(text[m.end():]):
+        return text
+    digits = m.group(0).replace(",", "")
+    if not digits.isdigit():
+        return format_pdf_value(value)
+    return f"{int(digits):,}원"
+
+
 _jinja_env = Environment(
     loader=FileSystemLoader(_TEMPLATE_DIR),
     autoescape=select_autoescape(["html"]),
@@ -120,6 +162,8 @@ _jinja_env.filters["key_info_label"] = format_key_info_label
 _jinja_env.filters["risk_type_label"] = format_risk_type
 _jinja_env.filters["contract_type_label"] = format_contract_type
 _jinja_env.filters["pdf_value"] = format_pdf_value
+_jinja_env.filters["money"] = format_money
+_jinja_env.globals["MONEY_KEYS"] = MONEY_KEYS
 
 
 def generate_contract_pdf(contract_id: int, user_id: int, db: Session) -> tuple[bytes, str]:

--- a/app/templates/pdf/contract_report.html
+++ b/app/templates/pdf/contract_report.html
@@ -97,10 +97,10 @@
           <td class="k">{{ key | key_info_label }}</td>
           <td class="v">
             {% if val is mapping %}
-              {{ val.get('value') | pdf_value }}
+              {% if key in MONEY_KEYS %}{{ val.get('value') | money }}{% else %}{{ val.get('value') | pdf_value }}{% endif %}
               {% if val.get('reason') %}<br><span class="meta">근거: {{ val.get('reason') }}</span>{% endif %}
             {% else %}
-              {{ val | pdf_value }}
+              {% if key in MONEY_KEYS %}{{ val | money }}{% else %}{{ val | pdf_value }}{% endif %}
             {% endif %}
           </td>
         </tr>


### PR DESCRIPTION
## 개요

다운로드 PDF(`GET /api/v1/contracts/{id}/download/pdf`)의 핵심 정보 테이블에서 금액이 계약서 원문식 표현으로 노출되던 문제를 수정했습니다. 프론트 화면과 동일하게 숫자만 정리해 보여줍니다.

Closes #78

## 변경 사항

- **`app/services/pdf_service.py`**
  - `format_money()` 필터 추가 — 문자열에서 아라비아 숫자(콤마 포함)를 추출해 천 단위 콤마 + `원`으로 변환, 숫자 타입은 직접 포맷.
  - `MONEY_KEYS = {amount_text, amount_value, hourly_wage, monthly_wage}` 정의 및 Jinja 환경에 `money` 필터/글로벌 등록.
- **`app/templates/pdf/contract_report.html`**
  - 핵심 정보 테이블에서 키가 `MONEY_KEYS`에 속하면 `money`, 아니면 기존 `pdf_value` 필터 적용 (`{value, reason}` 매핑·스칼라 모두 처리).

## 결과

| 현재 | 변경 후 |
|---|---|
| `금 450,000,000원 (사억오천만원 정)` | `450,000,000원` |
| `450,000,000원 사억오천만원정` | `450,000,000원` |
| `450000000` | `450,000,000원` |

## 설계 메모

- 표시용 변환이며 **원본 데이터/API 응답은 변경하지 않음** (기존 PDF 라벨 변환 컨벤션과 동일).
- `weekly_work_hours` 등 숫자 필드나 `monthly_wage_is_estimated`(불리언)에는 적용하지 않아 `40 → 40원` 같은 오변환 없음.
- `5,000만원`식 한국어 단위 축약 표기는 잘못된 숫자로 바뀌지 않도록 원본을 유지 (만/억/천/조 단위 파싱은 범위 외).

## 검증

`format_money()` 단위 동작으로 위 3개 예시 + 숫자/불리언/빈값/비숫자 케이스 확인 완료. 테스트 러너가 없는 프로젝트라, 머지 전 완료된 계약서로 실제 PDF 다운로드 확인을 권장합니다.