### PR TITLE
feat: 회원 탈퇴 엔드포인트 추가 (DELETE /api/v1/auth/me)

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -16,6 +16,7 @@ from app.schemas.auth import (
 from app.schemas.contract import MessageResponse
 from app.services.auth_service import (
     signup, login, refresh_access_token, update_nickname, change_password,
+    delete_account,
     update_profile_image, delete_profile_image, profile_image_url,
     request_password_reset, verify_reset_token, confirm_password_reset,
     request_email_verification, confirm_email_verification,
@@ -76,6 +77,12 @@ def api_update_nickname(body: UpdateNicknameRequest, user: User = Depends(get_cu
 def api_change_password(body: ChangePasswordRequest, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     change_password(user=user, current_password=body.current_password, new_password=body.new_password, db=db)
     return MessageResponse(message="비밀번호가 변경되었습니다.")
+
+
+@router.delete("/me", response_model=MessageResponse, summary="회원 탈퇴 (계정 및 연관 데이터 영구 삭제)")
+def api_delete_account(user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    delete_account(user=user, db=db)
+    return MessageResponse(message="회원 탈퇴가 완료되었습니다. 그동안 이용해주셔서 감사합니다.")
 
 
 @router.api_route(

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -15,6 +15,8 @@ from app.models.user import User
 from app.models.social_account import SocialAccount
 from app.models.password_reset import PasswordResetToken
 from app.models.email_verification import EmailVerification
+from app.models.chat import ChatSession, ChatMessage
+from app.models.notification import Notification
 from app.integrations.email_client import send_email
 
 
@@ -168,6 +170,49 @@ def change_password(user: User, current_password: str, new_password: str, db: Se
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="새 비밀번호가 현재 비밀번호와 동일합니다.")
     user.password_hash = hash_password(new_password)
     db.commit()
+
+
+def delete_account(user: User, db: Session) -> None:
+    """회원 탈퇴 — 본인 계정과 연관 데이터를 모두 영구 삭제(hard delete)한다.
+
+    User에 cascade="all, delete-orphan"이 걸린 contracts·social_accounts는
+    db.delete(user)로 ORM 캐스케이드 삭제되지만, backref로만 연결된 채팅/알림/
+    비밀번호 재설정 토큰은 그대로 두면 ORM이 user_id를 NULL로 만들려다(컬럼이
+    NOT NULL) 실패하므로 db.delete(user) 전에 먼저 정리한다. 이메일 인증 레코드는
+    email 기준이라 함께 지운다. DB 커밋이 끝난 뒤 디스크의 계약서 파일·프로필
+    이미지를 제거한다(파일 삭제 실패는 무시 — 계정 삭제 자체는 유효).
+    """
+    # 1) 삭제 전 디스크 파일 경로 수집 (행이 사라지면 경로를 알 수 없음)
+    contract_file_paths = [c.file_path for c in user.contracts if c.file_path]
+    profile_relative = user.profile_image_path
+
+    # 2) ORM 캐스케이드가 없는 user 직속 데이터 정리 (채팅 메시지 → 세션 순)
+    session_ids = [row[0] for row in db.query(ChatSession.id).filter(ChatSession.user_id == user.id).all()]
+    if session_ids:
+        db.query(ChatMessage).filter(ChatMessage.session_id.in_(session_ids)).delete(synchronize_session=False)
+    db.query(ChatSession).filter(ChatSession.user_id == user.id).delete(synchronize_session=False)
+    db.query(Notification).filter(Notification.user_id == user.id).delete(synchronize_session=False)
+    db.query(PasswordResetToken).filter(PasswordResetToken.user_id == user.id).delete(synchronize_session=False)
+    db.query(EmailVerification).filter(EmailVerification.email == user.email).delete(synchronize_session=False)
+
+    # 3) contracts·social_accounts는 ORM 캐스케이드(delete-orphan)로 함께 삭제
+    db.delete(user)
+    db.commit()
+
+    # 4) 커밋 성공 후 디스크 파일 제거
+    for fp in contract_file_paths:
+        try:
+            if fp and os.path.exists(fp):
+                os.remove(fp)
+        except OSError:
+            pass
+    if profile_relative:
+        try:
+            profile_path = Path(settings.upload_dir) / profile_relative
+            if profile_path.is_file():
+                profile_path.unlink()
+        except OSError:
+            pass
 
 
 # ── 비밀번호 재설정 (이메일 링크 방식) ────────────────────────────────────────


### PR DESCRIPTION
## 개요

프론트의 회원 탈퇴 버튼에 대응하는 백엔드 엔드포인트가 없어 추가합니다.

Closes #80

## 변경 사항

- **`app/api/v1/auth.py`**
  - `DELETE /api/v1/auth/me` 추가 — JWT 인증된 본인 계정을 영구 삭제. body 없음, `MessageResponse` 반환.
- **`app/services/auth_service.py`**
  - `delete_account(user, db)` 추가.

## 동작

- **인증/확인**: JWT 인증만으로 처리(비밀번호 재확인 없음). 소셜 계정 포함 동작.
- **삭제 범위 (hard delete)**:
  - `contracts`, `social_accounts` — User에 `cascade="all, delete-orphan"`이 걸려 있어 `db.delete(user)`로 ORM 캐스케이드 삭제 (계약서의 분석/조항/위험/컴플라이언스 하위행 포함).
  - `chat_sessions`/`chat_messages`, `notifications`, `password_reset_tokens` — backref로만 연결돼 ORM 캐스케이드가 없음. 그대로 두면 `db.delete(user)` 시 ORM이 `user_id`(NOT NULL)를 NULL로 만들려다 실패하므로 **`db.delete(user)` 전에 먼저 정리**.
  - `email_verifications` — `email` 기준 행 삭제.
  - **디스크 파일**: 커밋 성공 후 계약서 업로드 파일과 프로필 이미지 제거(파일 삭제 실패는 무시 — 계정 삭제 자체는 유효).
- 탈퇴 후 기존 JWT는 `get_current_user`의 사용자 조회 실패로 자연히 401 처리됨.

## 검증

- `app.main` / 라우터 import 정상, `DELETE /me` 라우트 등록 확인.
- 테스트 러너가 없는 프로젝트라, 머지 전 실제 계정으로 탈퇴 → 연관 데이터/파일 정리 동작 확인을 권장합니다.

## 비고

`delete_account`의 채팅·알림 등 직속 테이블 정리는 현재 FK ON DELETE CASCADE 구성과 별개로, DB 제약 생성 방식(create_all/raw SQL/Alembic 혼재)에 의존하지 않도록 명시적으로 삭제합니다.