### PR TITLE
feat: 공유 응답에 법령 준수 검사 결과 포함

### DIFF
--- a/app/api/v1/shares.py
+++ b/app/api/v1/shares.py
@@ -4,6 +4,7 @@ from app.db.session import get_db
 from app.schemas.share import (
     ShareVerifyRequest, ShareVerifyResponse,
     SharedContractResponse, SharedAnalysisResult, SharedRiskClause,
+    SharedComplianceResult,
 )
 from app.services.share_service import verify_share_password, get_shared_contract
 
@@ -61,10 +62,23 @@ def api_get_shared_contract(
         for rc in (contract.risk_clauses or [])
     ]
 
+    compliance_results = [
+        SharedComplianceResult(
+            clause_id=cr.clause_id,
+            clause_title=cr.clause_title,
+            clause_text=cr.clause_text,
+            status=cr.status,
+            reason=cr.reason,
+            law_references=cr.law_references,
+        )
+        for cr in (contract.compliance_results or [])
+    ]
+
     return SharedContractResponse(
         contract_id=contract.id,
         original_filename=contract.original_filename,
         contract_type=contract.contract_type.value,
         analysis=analysis,
         risk_clauses=risk_clauses,
+        compliance_results=compliance_results,
     )

--- a/app/schemas/share.py
+++ b/app/schemas/share.py
@@ -60,15 +60,26 @@ class SharedRiskClause(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class SharedComplianceResult(BaseModel):
+    clause_id: str
+    clause_title: Optional[str] = None
+    clause_text: str
+    status: str  # 위반 | 주의 | 적합 | 검토불가
+    reason: Optional[str] = None
+    law_references: Optional[List[Any]] = None
+    model_config = {"from_attributes": True}
+
+
 class SharedAnalysisResult(BaseModel):
     key_info: Optional[Any] = None
     summary: Optional[str] = None
 
 
 class SharedContractResponse(BaseModel):
-    """공유받은 사람에게 노출되는 데이터 — 분석 결과 + 위험 조항 + 근거만."""
+    """공유받은 사람에게 노출되는 데이터 — 분석 결과 + 위험 조항 + 근거 + 법령 준수 검사."""
     contract_id: int
     original_filename: str
     contract_type: str
     analysis: Optional[SharedAnalysisResult] = None
     risk_clauses: List[SharedRiskClause] = []
+    compliance_results: List[SharedComplianceResult] = []


### PR DESCRIPTION
## 개요

공유 페이지 프론트에 `법령 준수 검사` 섹션이 추가됐으나, `GET /api/v1/shares/{token}` 응답에 법령 준수 데이터가 없어 항상 "정보 없음"만 표시되던 문제를 해결합니다.

Closes #82

## 변경 사항

- **`app/schemas/share.py`**
  - `SharedComplianceResult` 스키마 추가 — `clause_id`, `clause_title`, `clause_text`, `status`(위반/주의/적합/검토불가), `reason`, `law_references`.
  - `SharedContractResponse`에 `compliance_results: List[SharedComplianceResult]` 필드 추가.
- **`app/api/v1/shares.py`**
  - `GET /{token}` 응답에서 `contract.compliance_results`를 직렬화해 반환.

## 응답 예시

```json
{
  "contract_id": 1,
  "original_filename": "근로계약서.pdf",
  "contract_type": "labor",
  "analysis": { "...": "..." },
  "risk_clauses": [ ... ],
  "compliance_results": [
    {
      "clause_id": "c1",
      "clause_title": "제3조 (근로시간)",
      "clause_text": "...",
      "status": "위반",
      "reason": "...",
      "law_references": [{ "law_name": "근로기준법", "article_no": "제50조" }]
    }
  ]
}
```

## 설계 메모

- 필드명은 프론트가 인식하는 목록(`compliance_results` 등) 중 snake_case `compliance_results`를 사용.
- 형태는 로그인 사용자용 계약 상세 응답(`ComplianceResultResponse`)과 동일하게 맞추되, 공유 응답 컨벤션(내부 식별자 비노출)에 따라 row `id`는 제외 (`SharedRiskClause`와 동일한 방침).
- 스키마 변경이 아니라 응답 직렬화 추가이므로 DB 마이그레이션 불필요.

## 검증

- `app.main` import 정상, `SharedContractResponse` 직렬화 시 `compliance_results`가 snake_case로 출력됨을 확인.
- 테스트 러너가 없는 프로젝트라, 머지 전 법령 준수 결과가 있는 완료 계약서로 공유 링크 조회 동작 확인을 권장합니다.