### PR TITLE
docs: CLAUDE.md 스키마 관리 설명에 수동 SQL 트랙 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Five routers, all mounted in [app/main.py](app/main.py): `auth`, `contracts`, `c
 - [app/core/config.py](app/core/config.py) — `settings` singleton (Pydantic Settings from `.env`). Single source of truth for all config; has computed properties like `database_url`, `*_list`, `*_bytes`.
 - [app/core/security.py](app/core/security.py) — JWT create/decode, password hashing, and the `get_current_user` dependency (`OAuth2PasswordBearer`). Access token 60 min, refresh 7 days.
 - [app/db/session.py](app/db/session.py) — `engine`, `SessionLocal`, `Base`, and the `get_db()` dependency injected into every DB-touching route.
-- [app/db/init_db.py](app/db/init_db.py) — `init_db()` runs `Base.metadata.create_all()` on startup (lifespan in main.py). **Schema is managed by BOTH this and Alembic** — `create_all` will create any missing table on boot, so a forgotten migration can silently "work" locally; always also write the Alembic migration for schema changes.
+- [app/db/init_db.py](app/db/init_db.py) — `init_db()` runs `Base.metadata.create_all()` on startup (lifespan in main.py). **Schema is managed by THREE mechanisms** — `create_all` (boots any missing table, so a forgotten migration can silently "work" locally), Alembic ([alembic/versions/](alembic/versions/), the source of truth), and hand-written SQL in [scripts/](scripts/) (`migrate_2026_05_*.sql` applied manually against shared/prod DBs) plus the original [database/schema.sql](database/schema.sql). For any schema change, always write the Alembic migration; the raw SQL scripts are a parallel manual track, not auto-applied.
 
 ### Contract analysis flow (async state machine)
 Status: `UPLOADED → PENDING → PROCESSING → COMPLETED / FAILED` (`ContractStatus` enum).


### PR DESCRIPTION
## 개요

`CLAUDE.md`의 스키마 관리 설명을 보강합니다. 기존에는 `create_all` + Alembic 두 가지로만 설명돼 있었으나, 실제 레포에는 세 번째 트랙이 존재합니다.

## 변경 사항

- 스키마 관리 메커니즘을 "두 가지"에서 "세 가지"로 수정:
  - `create_all()` (부팅 시 누락 테이블 생성)
  - Alembic (`alembic/versions/`, source of truth)
  - 손으로 작성한 `scripts/migrate_2026_05_*.sql` + `database/schema.sql`
- 수동 SQL 트랙은 자동 적용되지 않는 별도 경로임을 명시. 스키마 변경 시 Alembic 마이그레이션 작성 지침은 유지.

문서 변경만 포함하며 코드/스키마 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)