### PR TITLE
feat: 계약서 삭제 이력 조회 API 추가 (GET /api/v1/contracts/deleted)

### DIFF
--- a/alembic/versions/c5a1b2d3e4f6_add_deleted_contracts.py
+++ b/alembic/versions/c5a1b2d3e4f6_add_deleted_contracts.py
@@ -1,0 +1,45 @@
+"""add_deleted_contracts
+
+Revision ID: c5a1b2d3e4f6
+Revises: 71d7f2a38428
+Create Date: 2026-06-06 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c5a1b2d3e4f6'
+down_revision: Union[str, None] = '71d7f2a38428'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'deleted_contracts',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('original_contract_id', sa.Integer(), nullable=False),
+        sa.Column('original_filename', sa.String(length=500), nullable=False),
+        sa.Column('file_type', sa.String(length=50), nullable=True),
+        sa.Column('contract_type', sa.String(length=50), nullable=True),
+        sa.Column('status_at_deletion', sa.String(length=50), nullable=True),
+        sa.Column('contract_created_at', sa.DateTime(), nullable=True),
+        sa.Column('deleted_at', sa.DateTime(), server_default=sa.func.now(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_deleted_contracts_user_id', 'deleted_contracts', ['user_id'])
+    op.create_index('ix_deleted_contracts_original_contract_id', 'deleted_contracts', ['original_contract_id'])
+    op.create_index('ix_deleted_contracts_deleted_at', 'deleted_contracts', ['deleted_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_deleted_contracts_deleted_at', table_name='deleted_contracts')
+    op.drop_index('ix_deleted_contracts_original_contract_id', table_name='deleted_contracts')
+    op.drop_index('ix_deleted_contracts_user_id', table_name='deleted_contracts')
+    op.drop_table('deleted_contracts')

--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -11,6 +11,7 @@ from app.schemas.contract import (
     AnalysisResultResponse, RiskClauseResponse, MessageResponse,
     AnalyzeAcceptedResponse, ContractStatusResponse, ClauseResponse, ClauseListResponse,
     ComplianceResultResponse,
+    DeletedContractListResponse, DeletedContractItem,
 )
 from app.schemas.share import (
     ShareCreateRequest, ShareCreateResponse,
@@ -18,7 +19,7 @@ from app.schemas.share import (
 )
 from app.services.contract_service import (
     upload_contract, upload_contract_from_images,
-    get_contract_by_id, get_contracts_by_user, delete_contract,
+    get_contract_by_id, get_contracts_by_user, delete_contract, get_deleted_contracts,
     trigger_analysis, analyze_contract_background, get_clauses,
 )
 from app.services.share_service import (
@@ -72,6 +73,18 @@ def api_list_contracts(skip: int = Query(0, ge=0), limit: int = Query(20, ge=1, 
                           if c.status.value == "completed" else None),
             created_at=c.created_at, updated_at=c.updated_at)
         for c in contracts])
+
+
+# 주의: 경로 매칭 순서상 /{contract_id} 보다 반드시 먼저 선언해야 한다
+# (그렇지 않으면 "deleted"가 contract_id로 해석됨).
+@router.get("/deleted", response_model=DeletedContractListResponse, summary="계약서 삭제 이력 조회")
+def api_list_deleted_contracts(skip: int = Query(0, ge=0), limit: int = Query(20, ge=1, le=100),
+                               user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    total, items = get_deleted_contracts(user_id=user.id, db=db, skip=skip, limit=limit)
+    return DeletedContractListResponse(
+        total=total,
+        deleted_contracts=[DeletedContractItem.model_validate(it) for it in items],
+    )
 
 
 @router.get("/{contract_id}", response_model=ContractDetailResponse, summary="계약서 상세 조회")

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -1,5 +1,5 @@
 from app.db.session import engine, Base
-from app.models import user, contract, analysis, chat, social_account, notification, password_reset, contract_share, email_verification  # noqa: F401
+from app.models import user, contract, analysis, chat, social_account, notification, password_reset, contract_share, email_verification, deleted_contract  # noqa: F401
 
 
 def init_db():

--- a/app/models/deleted_contract.py
+++ b/app/models/deleted_contract.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, func
+from app.db.session import Base
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DeletedContract: 계약서 삭제 이력
+# DELETE /contracts/{id} 시 원본 계약서는 hard delete 되므로, 삭제 직전 메타데이터를
+# 이 테이블에 1행 기록해 둔다. GET /contracts/deleted 가 이 테이블을 조회한다.
+# (프론트가 localStorage로 임시 보관하던 삭제 이력을 서버로 이관 — 기기/브라우저 무관)
+# ──────────────────────────────────────────────────────────────────────────────
+class DeletedContract(Base):
+    __tablename__ = "deleted_contracts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # 소유자 — 사용자 탈퇴 시 함께 제거 (FK ON DELETE CASCADE)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    # 삭제된 원본 계약서의 id (프론트 이력 매칭용). 원본 행은 이미 삭제됐으므로 FK 아님.
+    original_contract_id = Column(Integer, nullable=False, index=True)
+    # 삭제 시점의 메타데이터 스냅샷 (원본 행이 사라져도 이력은 보존)
+    original_filename = Column(String(500), nullable=False)
+    file_type = Column(String(50), nullable=True)
+    contract_type = Column(String(50), nullable=True)        # 삭제 당시 ContractType 값
+    status_at_deletion = Column(String(50), nullable=True)   # 삭제 당시 ContractStatus 값
+    contract_created_at = Column(DateTime, nullable=True)     # 원본 업로드 일시
+    deleted_at = Column(DateTime, server_default=func.now(), index=True)

--- a/app/schemas/contract.py
+++ b/app/schemas/contract.py
@@ -58,6 +58,23 @@ class ContractListResponse(BaseModel):
     contracts: List[ContractListItem]
 
 
+class DeletedContractItem(BaseModel):
+    id: int                              # 이력 행 id
+    original_contract_id: int            # 삭제된 원본 계약서 id
+    original_filename: str
+    file_type: Optional[str] = None
+    contract_type: Optional[str] = None
+    status_at_deletion: Optional[str] = None
+    contract_created_at: Optional[datetime] = None  # 원본 업로드 일시
+    deleted_at: datetime
+    model_config = {"from_attributes": True}
+
+
+class DeletedContractListResponse(BaseModel):
+    total: int
+    deleted_contracts: List[DeletedContractItem]
+
+
 class AnalysisResultResponse(BaseModel):
     key_info: Optional[Any] = None
     clauses: Optional[List[Any]] = None

--- a/app/services/contract_service.py
+++ b/app/services/contract_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session, selectinload
 from app.core.config import settings
 from app.db.session import SessionLocal
 from app.models.contract import Contract, ContractStatus
+from app.models.deleted_contract import DeletedContract
 from app.models.analysis import AnalysisResult, RiskClause, ContractClause, ComplianceResult
 from app.integrations.ai_client import ai_client
 from app.integrations.mappers import (
@@ -211,10 +212,33 @@ def get_contracts_by_user(user_id: int, db: Session, skip: int = 0, limit: int =
 
 def delete_contract(contract_id: int, user_id: int, db: Session) -> None:
     contract = get_contract_by_id(contract_id, user_id, db)
+    # 원본은 hard delete 되므로 삭제 직전 메타데이터를 이력 테이블에 스냅샷으로 남긴다.
+    db.add(DeletedContract(
+        user_id=user_id,
+        original_contract_id=contract.id,
+        original_filename=contract.original_filename,
+        file_type=contract.file_type,
+        contract_type=contract.contract_type.value if contract.contract_type else None,
+        status_at_deletion=contract.status.value if contract.status else None,
+        contract_created_at=contract.created_at,
+    ))
     if os.path.exists(contract.file_path):
         os.remove(contract.file_path)
     db.delete(contract)
     db.commit()
+
+
+def get_deleted_contracts(user_id: int, db: Session, skip: int = 0, limit: int = 20):
+    """본인 계약서 삭제 이력 — 최근 삭제순."""
+    query = db.query(DeletedContract).filter(DeletedContract.user_id == user_id)
+    total = query.count()
+    items = (
+        query.order_by(DeletedContract.deleted_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    return total, items
 
 
 def get_clauses(contract_id: int, user_id: int, db: Session) -> list[ContractClause]:


### PR DESCRIPTION
## 개요

계약서 삭제 이력을 프론트 `localStorage.deletedContracts`가 아닌 서버에서 조회하도록 전용 API를 추가합니다. 기기/브라우저 무관, 조작 불가, 서버 실제 삭제와 일치하는 신뢰 가능한 이력을 제공합니다.

Closes #85

## 설계 결정

- **저장 방식**: 전용 이력 테이블 (`deleted_contracts`). 기존 hard delete(행+파일 제거)는 그대로 유지해 저장공간을 확보하고, 삭제 직전 메타데이터 스냅샷만 이력으로 남깁니다. 기존 목록/상세 쿼리에 영향 없음.
- **API 형태**: 전용 엔드포인트 `GET /api/v1/contracts/deleted`.

## 변경 사항

- **모델** `app/models/deleted_contract.py` — `DeletedContract`(`deleted_contracts`). 컬럼: `user_id`(FK users.id, **ON DELETE CASCADE** — 탈퇴 시 정리), `original_contract_id`, `original_filename`, `file_type`, `contract_type`, `status_at_deletion`, `contract_created_at`(원본 업로드 일시), `deleted_at`. `init_db.py`에 등록.
- **서비스** `app/services/contract_service.py`
  - `delete_contract` — 삭제 직전 `DeletedContract` 1행 기록 후 기존 로직(파일 제거 + `db.delete`).
  - `get_deleted_contracts(user_id, skip, limit)` — 최근 삭제순, 페이지네이션.
- **스키마** `app/schemas/contract.py` — `DeletedContractItem`, `DeletedContractListResponse`.
- **라우터** `app/api/v1/contracts.py` — `GET /deleted` 추가. **경로 매칭 순서상 `/{contract_id}`보다 먼저 선언**(아니면 "deleted"가 contract_id로 해석됨).
- **마이그레이션** `alembic/versions/c5a1b2d3e4f6_add_deleted_contracts.py` — 테이블 + 인덱스(user_id, original_contract_id, deleted_at).

## 응답 예시

```
GET /api/v1/contracts/deleted?skip=0&limit=20
```
```json
{
  "total": 1,
  "deleted_contracts": [
    {
      "id": 12,
      "original_contract_id": 47,
      "original_filename": "근로계약서.pdf",
      "file_type": ".pdf",
      "contract_type": "labor",
      "status_at_deletion": "completed",
      "contract_created_at": "2026-05-01T10:00:00",
      "deleted_at": "2026-06-06T09:30:00"
    }
  ]
}
```

## ⚠️ 배포 시 필요한 명령

스키마 변경(신규 테이블)이므로 **마이그레이션 적용이 필요**합니다:

```bash
alembic upgrade head
```

(로컬은 부팅 시 `create_all`이 테이블을 만들어 주지만, 운영/공유 DB에는 위 명령으로 적용)

## 검증

- `app.main` import 정상, `/deleted`가 `/{contract_id}`보다 먼저 등록됨을 확인.
- `alembic history` 단일 head(`71d7f2a38428 -> c5a1b2d3e4f6`) 확인.
- 테스트 러너가 없는 프로젝트라, 머지 전 실제 삭제 → `GET /contracts/deleted` 이력 노출 동작 확인을 권장합니다.