### PR TITLE
chore: .mailmap 추가

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+# Claude(AI 어시스턴트)의 co-author 크레딧을 실제 작성자(yenim)로 합쳐
+# GitHub 기여자 목록에 별도 인물로 표시되지 않도록 한다.
+# 형식: <표준 이름> <표준 이메일> <원본 이름> <원본 이메일>
+yenim <kimyenim0815@gmail.com> Claude Opus 4.8 <noreply@anthropic.com>


### PR DESCRIPTION
## 배경
GitHub 기여자(Contributors) 목록에 `Claude Opus 4.8 <noreply@anthropic.com>`이 별도 인물로 표시됨.
원인: 기본 브랜치(dev)의 커밋 ca62c67(#72/#73) 메시지에 `Co-authored-by: Claude` 트레일러가 포함됨.

## 변경
- `.mailmap` 추가: `Claude Opus 4.8 <noreply@anthropic.com>` → `yenim <kimyenim0815@gmail.com>` 매핑
- 해당 co-author 크레딧이 실제 작성자(yenim)로 합쳐져, 기여자 그래프에서 Claude가 별도로 표시되지 않음

## 영향 / 안전성
- 히스토리 재작성 없음 → 해시 불변 → **force-push 불필요**, 팀원 로컬 영향 없음
- 검증: `git check-mailmap "Claude Opus 4.8 <noreply@anthropic.com>"` → `yenim <kimyenim0815@gmail.com>`

## 한계
- 커밋 메시지 본문의 `Co-authored-by` 텍스트 자체는 남음(.mailmap은 집계 표시만 변경). 기여자 그래프(Insights → Contributors)에서 사라지는 것이 목적.
- 머지 후 GitHub 재집계까지 시간이 걸릴 수 있음.