### PR TITLE
fix: 재분석 시 이전 분석 결과가 내려오는 문제 수정

### DIFF
--- a/alembic/versions/e7c3f9a1b2d4_add_analysis_requested_at_to_contracts.py
+++ b/alembic/versions/e7c3f9a1b2d4_add_analysis_requested_at_to_contracts.py
@@ -1,0 +1,30 @@
+"""add_analysis_requested_at_to_contracts
+
+Revision ID: e7c3f9a1b2d4
+Revises: c5a1b2d3e4f6
+Create Date: 2026-06-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e7c3f9a1b2d4'
+down_revision: Union[str, None] = 'c5a1b2d3e4f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 분석(재분석 포함) 요청 시각 — 재분석 신선도 판별의 기준 시각.
+    op.add_column(
+        'contracts',
+        sa.Column('analysis_requested_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('contracts', 'analysis_requested_at')

--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -132,6 +132,9 @@ def api_get_contract(contract_id: int, user: User = Depends(get_current_user), d
                                   file_type=contract.file_type, status=contract.status.value,
                                   analysis_status=contract.status.value, contract_type=contract.contract_type.value,
                                   extracted_text=contract.extracted_text, created_at=contract.created_at, updated_at=contract.updated_at,
+                                  job_id=contract.analysis_job_id,
+                                  analysis_requested_at=contract.analysis_requested_at,
+                                  analysis_updated_at=contract.updated_at,
                                   analysis_completed_at=contract.analysis_completed_at,
                                   analysis=analysis, risk_clauses=risk_clauses,
                                   clauses=clauses, compliance_results=compliance_results,
@@ -156,15 +159,20 @@ def api_delete_contract(contract_id: int, user: User = Depends(get_current_user)
 async def api_request_analysis(
     contract_id: int,
     background_tasks: BackgroundTasks,
+    force: bool = Query(False, description="기존 분석 결과가 있어도 새 분석 job을 강제 생성"),
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    contract = trigger_analysis(contract_id, user.id, db)
+    contract = trigger_analysis(contract_id, user.id, db, force=force)
     background_tasks.add_task(analyze_contract_background, contract.id)
     return AnalyzeAcceptedResponse(
         message=f"'{contract.original_filename}' 분석이 요청되었습니다.",
-        status="pending",
+        status=contract.status.value,
         poll_url=f"/api/v1/contracts/{contract_id}/status",
+        contract_id=contract.id,
+        job_id=contract.analysis_job_id,
+        analysis_requested_at=contract.analysis_requested_at,
+        force=force,
     )
 
 
@@ -173,9 +181,12 @@ def api_get_analysis_status(contract_id: int, user: User = Depends(get_current_u
     contract = get_contract_by_id(contract_id, user.id, db)
     return ContractStatusResponse(
         contract_id=contract.id,
+        job_id=contract.analysis_job_id,
         status=contract.status.value,
         contract_type=contract.contract_type.value,
+        analysis_requested_at=contract.analysis_requested_at,
         analysis_started_at=contract.analysis_started_at,
+        analysis_updated_at=contract.updated_at,
         analysis_completed_at=contract.analysis_completed_at,
         error=contract.analysis_error,
     )

--- a/app/models/contract.py
+++ b/app/models/contract.py
@@ -58,6 +58,9 @@ class Contract(Base):
     ocr_pages = Column(JSON, nullable=True)               # [{page_index, text}] 페이지별 OCR 결과
     # 분석 오류
     analysis_error = Column(Text, nullable=True)          # 분석 실패 사유
+    # 분석(재분석 포함) 요청 시각 — 새 분석 job의 기준 시각.
+    # 재분석 신선도 판별의 앵커: 완료 시각이 이 값 이후여야 "이번 요청의 결과"다.
+    analysis_requested_at = Column(DateTime, nullable=True)
     # 분석 시작 시간
     analysis_started_at = Column(DateTime, nullable=True)
     # 분석 완료 시간
@@ -80,3 +83,14 @@ class Contract(Base):
     clauses = relationship("ContractClause", back_populates="contract", cascade="all, delete-orphan")
     # 법령 준수 검사 결과 (1:N 관계)
     compliance_results = relationship("ComplianceResult", back_populates="contract", cascade="all, delete-orphan")
+
+    @property
+    def analysis_job_id(self):
+        """현재 분석 job 식별자 — 별도 컬럼 없이 contract_id + 요청 시각으로 파생.
+
+        매 분석 요청마다 analysis_requested_at이 갱신되므로 job_id도 새로 바뀐다.
+        프론트가 "지금 폴링 중인 상태가 내가 방금 요청한 job의 것인지" 확인하는 데 사용.
+        """
+        if self.analysis_requested_at is None:
+            return None
+        return f"{self.id}-{int(self.analysis_requested_at.timestamp())}"

--- a/app/schemas/contract.py
+++ b/app/schemas/contract.py
@@ -27,6 +27,10 @@ class ContractDetailResponse(BaseModel):
     extracted_text: Optional[str] = None
     created_at: datetime
     updated_at: datetime
+    # 분석 job 식별/신선도 — 재분석 시 프론트가 최신 결과 여부를 검증하는 데 사용.
+    job_id: Optional[str] = None
+    analysis_requested_at: Optional[datetime] = None
+    analysis_updated_at: Optional[datetime] = None
     analysis_completed_at: Optional[datetime] = None
     analysis: Optional["AnalysisResultResponse"] = None
     risk_clauses: Optional[List["RiskClauseResponse"]] = None
@@ -131,13 +135,25 @@ class AnalyzeAcceptedResponse(BaseModel):
     message: str
     status: str
     poll_url: str
+    contract_id: int
+    # 이번 분석 job 식별자 (contract_id + 요청 시각으로 파생). 재분석마다 새 값.
+    job_id: Optional[str] = None
+    analysis_requested_at: Optional[datetime] = None
+    # 재분석 강제 요청 여부 (프론트가 보낸 force 플래그 에코)
+    force: bool = False
 
 
 class ContractStatusResponse(BaseModel):
     contract_id: int
+    # 폴링 중인 상태가 어느 job의 것인지 식별 — analyze 응답의 job_id와 비교
+    job_id: Optional[str] = None
     status: str
     contract_type: Optional[str] = None
+    analysis_requested_at: Optional[datetime] = None
     analysis_started_at: Optional[datetime] = None
+    # 마지막 상태 변경 시각 (Contract.updated_at). 진행 갱신 추적용.
+    analysis_updated_at: Optional[datetime] = None
+    # 재분석 중에는 None. status==completed 이고 이 값이 requested_at 이후일 때만 신뢰.
     analysis_completed_at: Optional[datetime] = None
     error: Optional[str] = None
     model_config = {"from_attributes": True}

--- a/app/services/contract_service.py
+++ b/app/services/contract_service.py
@@ -249,17 +249,26 @@ def get_clauses(contract_id: int, user_id: int, db: Session) -> list[ContractCla
     ).order_by(ContractClause.order).all()
 
 
-def trigger_analysis(contract_id: int, user_id: int, db: Session) -> Contract:
+def trigger_analysis(contract_id: int, user_id: int, db: Session, force: bool = False) -> Contract:
     """
     분석 요청 수락 단계.
     상태를 PENDING으로 바꾸고 반환만 한다.
     실제 AI 호출은 analyze_contract_background()가 담당.
+
+    재분석(force) 핵심: 이전 분석의 시작/완료 시각을 즉시 None으로 리셋한다.
+    그래야 새 분석이 진행되는 동안 status/detail 응답이 이전 completed 시각을
+    물고 내려가지 않는다(프론트가 옛 결과를 새 결과로 오인하는 문제 차단).
+    이전 분석 결과 행(AnalysisResult 등)은 그대로 보존했다가 새 분석 완료 시
+    analyze_contract_background()에서 교체한다 — 재분석 실패 시 직전 결과 유지 목적.
     """
     contract = get_contract_by_id(contract_id, user_id, db)
     if contract.status == ContractStatus.PROCESSING:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="이미 분석 중입니다.")
     contract.status = ContractStatus.PENDING
-    contract.analysis_error = None  # 재분석 시 이전 오류 초기화
+    contract.analysis_error = None              # 재분석 시 이전 오류 초기화
+    contract.analysis_requested_at = datetime.now(timezone.utc)  # 새 job 기준 시각
+    contract.analysis_started_at = None         # 이전 job의 시작/완료 시각 무효화
+    contract.analysis_completed_at = None
     db.commit()
     db.refresh(contract)
     return contract

--- a/scripts/migrate_2026_06_contract_analysis_requested_at.sql
+++ b/scripts/migrate_2026_06_contract_analysis_requested_at.sql
@@ -1,0 +1,27 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- contracts 테이블에 analysis_requested_at 컬럼 추가 (2026-06)
+--
+-- 추가 내역:
+--   analysis_requested_at DATETIME NULL  — 분석(재분석 포함) 요청 시각
+--
+-- 왜:
+--   기존 계약서 재분석 시, 이전 분석의 completed 상태/시각이 status·detail 응답에
+--   계속 내려가 프론트가 옛 결과를 새 결과로 오인하는 문제가 있었다. 분석 요청마다
+--   이 시각을 갱신하고 시작/완료 시각을 리셋하여, "이번 요청 이후 완료된 결과"만
+--   신뢰하도록 신선도 기준을 제공한다. job_id는 (contract_id + 이 시각)으로 파생.
+--
+-- 실행:
+--   mysql -u root -p clair_db < scripts/migrate_2026_06_contract_analysis_requested_at.sql
+--
+-- 멱등성:
+--   ADD COLUMN은 INFORMATION_SCHEMA로 존재 확인 후 실행 — 여러 번 돌려도 안전.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'contracts' AND COLUMN_NAME = 'analysis_requested_at');
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE contracts ADD COLUMN analysis_requested_at DATETIME NULL',
+  'SELECT ''contracts.analysis_requested_at already exists'' AS skip_reason');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'contracts.analysis_requested_at 마이그레이션 완료' AS result;


### PR DESCRIPTION
Closes #88

## 문제
계약서 관리 화면에서 기존 계약서를 `force=true`로 재분석해도, `GET /{id}/status`·`GET /{id}` 응답에 이전 `completed` 상태/시각 또는 이전 `analysis_result`가 계속 내려와 프론트가 새 결과와 이전 결과를 구분하기 어려웠음. (신규 업로드 분석은 정상)

## 원인
`trigger_analysis()`가 상태만 `PENDING`으로 바꾸고 이전 분석의 `analysis_started_at`/`analysis_completed_at`을 리셋하지 않아, 재분석 진행 중에도 응답이 직전 완료 시각을 그대로 물고 내려감.

## 변경
- `Contract.analysis_requested_at` 컬럼 추가 (재분석 신선도 기준 시각) + Alembic 마이그레이션/수동 SQL
- `analysis_job_id` = `{contract_id}-{요청 시각 epoch}` 파생 프로퍼티
- `trigger_analysis(force)`: 요청 시각 기록 + `started_at`/`completed_at` 즉시 None 리셋. **이전 결과 행은 보존**했다 새 분석 완료 시 교체(재분석 실패 시 직전 결과 유지)
- `POST /analyze`에 `force` 쿼리 파라미터 + 응답에 `contract_id`/`job_id`/`analysis_requested_at`/`force`
- `GET /status`·`GET /{id}`에 `job_id`/`analysis_requested_at`/`analysis_updated_at` 추가

## 검증
- 서버 기동 + OpenAPI에 `force` 파라미터·새 응답 필드 노출 확인
- DB 단위 테스트: COMPLETED 상태 계약서에 `force=true` 재분석 요청 → `status=pending`, `started_at/completed_at=None`, `analysis_requested_at` 갱신, `job_id` 변경 확인 (PASS)

## 프론트 영향
완료 판정을 `status === 'completed' && analysis_completed_at >= analysis_requested_at` (또는 analyze/status의 `job_id` 일치)로 게이팅하면 완전히 견고. 백엔드 변경만으로도 재분석 중 `completed_at`이 null로 내려가 오인은 차단됨.

## DB 적용 필요
`alembic upgrade head` (공유/운영 DB는 `scripts/migrate_2026_06_contract_analysis_requested_at.sql` 수동 적용)