### PR TITLE
chore: 분석 결과 PDF 보고서에서 '보고서 생성' 일시 표시 제거

### DIFF
--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -14,7 +14,6 @@ WeasyPrint(HTML→PDF)를 사용해 Jinja2 템플릿으로 한국어 분석 보�
 import os
 import platform
 import re
-from datetime import datetime
 from pathlib import Path
 
 # WeasyPrint import 전에 macOS 라이브러리 경로 설정 — 순서 중요
@@ -205,7 +204,6 @@ def generate_contract_pdf(contract_id: int, user_id: int, db: Session) -> tuple[
         original_filename=contract.original_filename,
         contract_type=contract.contract_type.value,
         analyzed_at=contract.analysis_completed_at or contract.updated_at,
-        generated_at=datetime.now(),
         key_info=(analysis.key_info if analysis else None),
         summary=(analysis.summary if analysis else None),
         risk_clauses=risk_clauses,

--- a/app/templates/pdf/contract_report.html
+++ b/app/templates/pdf/contract_report.html
@@ -83,8 +83,6 @@
       <span class="label label-contract-type">{{ contract_type | contract_type_label }}</span>
       &nbsp;
       분석일: {{ analyzed_at.strftime('%Y-%m-%d %H:%M') if analyzed_at else '-' }}
-      &nbsp;·&nbsp;
-      보고서 생성: {{ generated_at.strftime('%Y-%m-%d %H:%M') }}
     </div>
   </div>
 


### PR DESCRIPTION
Closes #90

## 변경
분석 결과 공유/다운로드 PDF 보고서 헤더에 표시되던 **'보고서 생성: {일시}'** 항목을 제거.

- `app/templates/pdf/contract_report.html`: 헤더 meta에서 '보고서 생성: ...' 줄과 앞 구분점(·) 제거 (분석일만 유지)
- `app/services/pdf_service.py`: 미사용이 된 `generated_at` 렌더 컨텍스트 변수 및 `datetime` import 정리

## 영향
- PDF 출력만 변경. API 응답/DB 스키마 변경 없음 → **마이그레이션 불필요**
- 프론트 작업 없음