### PR TITLE
chore: 분석 결과 PDF 보고서에서 '보고서 생성' 일시 표시 제거 재적용 (#90/#91 부활)

### DIFF
--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -14,7 +14,6 @@ WeasyPrint(HTML→PDF)를 사용해 Jinja2 템플릿으로 한국어 분석 보�
 import os
 import platform
 import re
-from datetime import datetime
 from pathlib import Path
 
 # WeasyPrint import 전에 macOS 라이브러리 경로 설정 — 순서 중요
@@ -205,7 +204,6 @@ def generate_contract_pdf(contract_id: int, user_id: int, db: Session) -> tuple[
         original_filename=contract.original_filename,
         contract_type=contract.contract_type.value,
         analyzed_at=contract.analysis_completed_at or contract.updated_at,
-        generated_at=datetime.now(),
         key_info=(analysis.key_info if analysis else None),
         summary=(analysis.summary if analysis else None),
         risk_clauses=risk_clauses,

--- a/app/templates/pdf/contract_report.html
+++ b/app/templates/pdf/contract_report.html
@@ -83,8 +83,6 @@
       <span class="label label-contract-type">{{ contract_type | contract_type_label }}</span>
       &nbsp;
       분석일: {{ analyzed_at.strftime('%Y-%m-%d %H:%M') if analyzed_at else '-' }}
-      &nbsp;·&nbsp;
-      보고서 생성: {{ generated_at.strftime('%Y-%m-%d %H:%M') }}
     </div>
   </div>
 


### PR DESCRIPTION
## 요약
#92(`8b2cf5a`)로 revert됐던 **#90/#91** 변경("분석 결과 PDF 보고서에서 '보고서 생성' 일시 표시 제거")을 다시 적용합니다.

## 방식
- `git revert 8b2cf5a` — revert 커밋을 되돌려 원래 변경을 복원
- 영향: PDF 보고서 템플릿/서비스에서 '보고서 생성' 일시 표시 제거 (4줄 삭제)

## 변경 파일
- `app/services/pdf_service.py`
- `app/templates/pdf/contract_report.html`

Closes #95