### PR TITLE
fix: 계약서 관리 분석 90% 멈춤 수정 (시각 직렬화 UTC 명시 + AI 타임아웃 상향)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,8 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173,h
 # ⚠️  macOS 주의: localhost가 IPv6(::1)로 resolve되어 uvicorn(IPv4)에 연결 실패할 수 있음
 #     반드시 127.0.0.1 을 사용할 것
 AI_SERVICE_URL=http://127.0.0.1:8001
-AI_SERVICE_TIMEOUT=300.0
+# OCR+다단계 LLM 분석이 최대 ~5분 소요되므로 여유 있게 설정 (초)
+AI_SERVICE_TIMEOUT=600.0
 GEMINI_API_KEY=
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -32,7 +32,7 @@ class Settings(BaseSettings):
 
     gemini_api_key: str = ""
     ai_service_url: str = "http://localhost:8001"
-    ai_service_timeout: float = 120.0   # OCR+LLM 분석은 최대 2분 허용
+    ai_service_timeout: float = 600.0   # OCR+다단계 LLM 분석이 최대 ~5분 소요 — 여유 있게 10분 허용
     cors_origins: str = "http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173,http://127.0.0.1:3000"
 
     google_client_id: str = ""

--- a/app/schemas/contract.py
+++ b/app/schemas/contract.py
@@ -1,6 +1,26 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, PlainSerializer
 from typing import Optional, List, Any
-from datetime import datetime
+from typing_extensions import Annotated
+from datetime import datetime, timezone
+
+
+def _serialize_utc(dt: Optional[datetime]) -> Optional[str]:
+    """
+    MySQL DATETIME은 타임존 정보를 저장하지 않아 naive datetime으로 읽힌다.
+    백엔드는 UTC 벽시계(datetime.now(timezone.utc))로 저장하므로, 직렬화 시
+    UTC 오프셋을 명시해 프론트(JS new Date())가 로컬시간(KST)으로 오해하지 않게 한다.
+    이 오프셋이 없으면 analysis_completed_at이 9시간 과거로 파싱돼
+    프론트의 '새 분석 완료' 시각 비교가 실패한다(계약서 관리 화면 로딩 90% 멈춤 원인).
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+# 타임존(UTC)을 명시해 직렬화하는 datetime 타입 — 모든 응답의 시각 필드에 사용
+UTCDateTime = Annotated[datetime, PlainSerializer(_serialize_utc, when_used="json")]
 
 
 class ContractUploadResponse(BaseModel):
@@ -9,7 +29,7 @@ class ContractUploadResponse(BaseModel):
     file_size: int
     file_type: str
     status: str
-    created_at: datetime
+    created_at: UTCDateTime
     message: str = "계약서가 성공적으로 업로드되었습니다."
     model_config = {"from_attributes": True}
 
@@ -25,9 +45,9 @@ class ContractDetailResponse(BaseModel):
     analysis_status: str
     contract_type: str
     extracted_text: Optional[str] = None
-    created_at: datetime
-    updated_at: datetime
-    analysis_completed_at: Optional[datetime] = None
+    created_at: UTCDateTime
+    updated_at: UTCDateTime
+    analysis_completed_at: Optional[UTCDateTime] = None
     analysis: Optional["AnalysisResultResponse"] = None
     risk_clauses: Optional[List["RiskClauseResponse"]] = None
     clauses: Optional[List["ClauseResponse"]] = None
@@ -48,8 +68,8 @@ class ContractListItem(BaseModel):
     # 분석 완료(COMPLETED) 계약서만 0~100 정수, 그 외에는 null.
     # 상세 API(GET /contracts/{id})의 safety_score와 동일 기준(compute_safety_score)
     safety_score: Optional[int] = None
-    created_at: datetime
-    updated_at: datetime
+    created_at: UTCDateTime
+    updated_at: UTCDateTime
     model_config = {"from_attributes": True}
 
 
@@ -65,8 +85,8 @@ class DeletedContractItem(BaseModel):
     file_type: Optional[str] = None
     contract_type: Optional[str] = None
     status_at_deletion: Optional[str] = None
-    contract_created_at: Optional[datetime] = None  # 원본 업로드 일시
-    deleted_at: datetime
+    contract_created_at: Optional[UTCDateTime] = None  # 원본 업로드 일시
+    deleted_at: UTCDateTime
     model_config = {"from_attributes": True}
 
 
@@ -80,7 +100,7 @@ class AnalysisResultResponse(BaseModel):
     clauses: Optional[List[Any]] = None
     summary: Optional[str] = None
     detected_objects: Optional[List[Any]] = None
-    created_at: datetime
+    created_at: UTCDateTime
     model_config = {"from_attributes": True}
 
 
@@ -137,8 +157,8 @@ class ContractStatusResponse(BaseModel):
     contract_id: int
     status: str
     contract_type: Optional[str] = None
-    analysis_started_at: Optional[datetime] = None
-    analysis_completed_at: Optional[datetime] = None
+    analysis_started_at: Optional[UTCDateTime] = None
+    analysis_completed_at: Optional[UTCDateTime] = None
     error: Optional[str] = None
     model_config = {"from_attributes": True}
 


### PR DESCRIPTION
## 요약
계약서 관리 화면에서 분석이 90%에서 멈추던 문제 수정.

## 원인
1. **시각 직렬화 타임존 누락** — `analysis_completed_at`이 오프셋 없이(`...T04:00:00`) 내려가 프론트 JS가 로컬(KST)로 9시간 과거로 파싱 → '새 분석 완료 시각 >= 요청 시각' 비교 영영 실패 → 90% 영구 정지. (홈 플로우는 `requireFreshAnalysis=false`라 가려져 있었음)
2. **AI 타임아웃 부족** — 분석 ~287초인데 타임아웃 120/300초 → 백엔드가 결과 못 받아 PROCESSING 정지/ FAILED.

## 변경
- `app/schemas/contract.py`: 응답 시각 필드를 UTC 오프셋 포함으로 직렬화하는 `UTCDateTime` 도입 (naive datetime → UTC 간주, `+00:00` 부착)
- `app/core/config.py`: `ai_service_timeout` 기본값 120 → 600
- `.env.example`: `AI_SERVICE_TIMEOUT` 300 → 600

## 검증
- 직렬화 출력이 `2026-06-09T04:00:00+00:00` 형태로 변경됨 확인.
- 프론트 코드 변경 없음(프론트 로직은 정상, 백엔드가 비교 불가능한 값을 준 것이 원인).
- 실제 계약서 관리 화면 업로드→분석 정상 완료 확인.

## 배포 주의
- 운영/공유 DB의 `.env`에도 `AI_SERVICE_TIMEOUT=600.0` 반영 필요(코드 기본값은 600으로 올렸으나 .env 값이 우선).

Closes #97