### PR TITLE
feat: 분석 요청 레이트리밋 및 AI 오류 메시지 전달 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ venv/
 .DS_Store
 .env
 uploads/
+
+# macOS 리소스 포크 메타데이터 (non-APFS 볼륨에서 생성됨)
+._*
+.DS_Store

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -54,6 +54,12 @@ class Settings(BaseSettings):
     mail_from: str = ""
     mail_from_name: str = "CLAIR"
 
+    # AI 분석 남용 방지 — 사용자당 분석 요청 횟수 제한.
+    # Gemini 호출은 건당 실비가 발생하므로, clair-ai의 월 예산 상한과 함께
+    # 2단 방어를 구성한다. 0 이하로 두면 해당 제한을 끈다.
+    analysis_rate_limit_per_hour: int = 3
+    analysis_rate_limit_per_day: int = 10
+
     frontend_base_url: str = "http://localhost:5173"
     social_callback_path: str = "/social-callback"
     password_reset_path: str = "/password-reset"

--- a/app/integrations/ai_client.py
+++ b/app/integrations/ai_client.py
@@ -13,6 +13,28 @@ from app.core.config import settings
 from app.integrations.ai_models import AIAnalysisResponse, AIQAResponse
 
 
+def _raise_for_status(resp: httpx.Response) -> None:
+    """오류 응답을 clair-ai가 보낸 detail 문구와 함께 올린다.
+
+    httpx의 raise_for_status()는 상태 코드만 담아 본문의 detail을 버린다.
+    예산 소진(429) 같은 케이스에서 사용자가 원인을 알 수 있어야 하므로,
+    detail이 있으면 그것을 예외 메시지로 쓴다. 이 메시지는 분석 실패 시
+    contract.analysis_error와 알림에 그대로 노출된다.
+    """
+    if not resp.is_error:
+        return
+    detail = None
+    try:
+        payload = resp.json()
+        if isinstance(payload, dict):
+            detail = payload.get("detail")
+    except Exception:
+        detail = None
+    if detail:
+        raise httpx.HTTPStatusError(str(detail), request=resp.request, response=resp)
+    resp.raise_for_status()
+
+
 class AIServiceClient:
     def __init__(self, base_url: str, timeout: float):
         self.base_url = base_url.rstrip("/")
@@ -37,7 +59,7 @@ class AIServiceClient:
                     "document_id": document_id,
                 },
             )
-            resp.raise_for_status()
+            _raise_for_status(resp)
             return AIAnalysisResponse.model_validate(resp.json())
 
     async def answer_question(
@@ -60,7 +82,7 @@ class AIServiceClient:
                     "clauses": clauses,
                 },
             )
-            resp.raise_for_status()
+            _raise_for_status(resp)
             return AIQAResponse.model_validate(resp.json())
 
     async def health_check(self) -> bool:

--- a/app/services/contract_service.py
+++ b/app/services/contract_service.py
@@ -249,6 +249,43 @@ def get_clauses(contract_id: int, user_id: int, db: Session) -> list[ContractCla
     ).order_by(ContractClause.order).all()
 
 
+def _enforce_analysis_rate_limit(user_id: int, db: Session) -> None:
+    """사용자당 분석 요청 횟수를 제한한다.
+
+    Gemini 호출은 건당 실비가 발생하므로, 한 사용자가 짧은 시간에 예산을
+    소진하는 것을 막는다. 전체 예산 상한은 clair-ai가 별도로 강제한다.
+
+    직전 분석 시작 시각(analysis_started_at)을 기준으로 센다. 백그라운드
+    태스크가 시작될 때 채워지므로 아주 짧은 순간에는 과소 집계될 수 있으나,
+    최종 방어선은 clair-ai의 월 예산 가드다.
+    """
+    from datetime import timedelta
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    windows = (
+        ("시간", settings.analysis_rate_limit_per_hour, now - timedelta(hours=1)),
+        ("일", settings.analysis_rate_limit_per_day, now - timedelta(days=1)),
+    )
+
+    for unit, limit, since in windows:
+        if limit <= 0:
+            continue
+        used = (
+            db.query(Contract)
+            .filter(
+                Contract.user_id == user_id,
+                Contract.analysis_started_at.isnot(None),
+                Contract.analysis_started_at >= since,
+            )
+            .count()
+        )
+        if used >= limit:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=f"분석 요청 한도를 초과했습니다. 1{unit}당 {limit}회까지 요청할 수 있습니다.",
+            )
+
+
 def trigger_analysis(contract_id: int, user_id: int, db: Session) -> Contract:
     """
     분석 요청 수락 단계.
@@ -256,6 +293,7 @@ def trigger_analysis(contract_id: int, user_id: int, db: Session) -> Contract:
     실제 AI 호출은 analyze_contract_background()가 담당.
     """
     contract = get_contract_by_id(contract_id, user_id, db)
+    _enforce_analysis_rate_limit(user_id, db)
     if contract.status == ContractStatus.PROCESSING:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="이미 분석 중입니다.")
     contract.status = ContractStatus.PENDING


### PR DESCRIPTION
Closes #100

## 요약

Gemini 호출은 건당 실비(약 40.9원)가 발생한다. 한 사용자가 짧은 시간에 예산을 소진하는 것을 막는 1차 방어선을 추가하고, AI 서비스 오류 원인이 사용자에게 전달되도록 고쳤다.

## 변경 내용

### 1. 사용자당 분석 요청 제한

`trigger_analysis`에서 시간당 3회 / 일 10회로 제한한다.

- `ANALYSIS_RATE_LIMIT_PER_HOUR`, `ANALYSIS_RATE_LIMIT_PER_DAY`로 조정 (0 이하면 해당 제한 해제)
- 기존 `Contract.analysis_started_at`을 기준으로 세므로 **스키마 변경·마이그레이션이 없다**
- 초과 시 429 + 한국어 안내

`analysis_started_at`은 백그라운드 태스크 시작 시 채워지므로 아주 짧은 순간에는 과소 집계될 수 있다. 최종 방어선은 clair-ai의 월 예산 가드다.

### 2. AI 오류 원인 전달 (`ai_client.py`)

`resp.raise_for_status()`는 상태 코드만 담고 응답 본문의 `detail`을 버린다. clair-ai가 예산 소진(429)과 함께 안내 문구를 보내도 사용자에게는 이렇게만 보였다.

```
Client error '429 Too Many Requests' for url 'http://127.0.0.1:8001/analyze'
```

`_raise_for_status()`를 추가해 `detail`이 있으면 그것을 예외 메시지로 쓰도록 했다. 이 메시지는 분석 실패 시 `contract.analysis_error`와 알림에 그대로 노출되므로, 이제 사용자가 원인을 알 수 있다.

```
이번 달(2026-08) Gemini API 예산을 모두 사용했습니다.
사용 5064.63원 / 예산 5000.0원. 다음 달에 자동으로 초기화됩니다.
```

## 검증

- 앱 로드 및 임포트 정상
- Python 3.9 런타임 제약 준수 (PEP 604 유니온 미사용)
- clair-ai를 띄우고 예산 초과 상태에서 429 + detail 전달 확인

## 관련

전체 월 예산 하드 스톱은 KS-LEXA/clair-ai#42에서 다룬다. 2단 방어 구성:

| 층 | 위치 | 역할 |
|---|---|---|
| 1차 | clair-backend (이 PR) | 사용자당 요청 빈도 제한 |
| 2차 | clair-ai | 전체 월 지출 상한 강제 |

## 기타

macOS 리소스 포크(`._*`)를 gitignore에 추가했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)