### PR TITLE
release: 배포 준비 반영 (dev → main)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+venv
+__pycache__
+**/__pycache__
+*.pyc
+._*
+.DS_Store
+.env
+uploads
+tests
+database
+scripts
+clair-frontend

--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,12 @@ PASSWORD_RESET_TOKEN_EXPIRE_MINUTES=30
 SHARE_PATH=/share
 SHARE_TOKEN_DEFAULT_EXPIRE_DAYS=7
 SHARE_ACCESS_TOKEN_EXPIRE_MINUTES=60
+
+
+# === AI 분석 남용 방지 (선택, 기본값 사용 권장) ===
+# Gemini 호출은 건당 실비(약 41원)가 발생한다.
+# 한 사용자가 짧은 시간에 예산을 소진하는 것을 막는 1차 방어선.
+# 전체 월 지출 상한은 clair-ai의 MONTHLY_BUDGET_KRW가 담당한다.
+# 0 이하로 두면 해당 제한이 꺼진다.
+ANALYSIS_RATE_LIMIT_PER_HOUR=3
+ANALYSIS_RATE_LIMIT_PER_DAY=10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# clair-backend — FastAPI REST API
+FROM python:3.11-slim
+
+# WeasyPrint(PDF 리포트)가 pango/cairo를 dlopen 하므로 런타임 라이브러리가 필요하다.
+# fonts-nanum은 필수: 없으면 한글 PDF가 전부 두부(□)로 렌더링된다.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpango-1.0-0 \
+        libpangoft2-1.0-0 \
+        libharfbuzz0b \
+        libffi8 \
+        shared-mime-info \
+        fonts-nanum \
+        && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app/ ./app/
+COPY alembic/ ./alembic/
+COPY alembic.ini ./
+
+# 업로드된 계약서 원본이 쌓이는 경로. 영속 볼륨을 마운트해야 재시작 후에도
+# 기존 계약서를 열 수 있다. 프로필 이미지도 이 아래에 저장된다.
+ENV UPLOAD_DIR=/data/uploads
+RUN mkdir -p /data/uploads
+VOLUME ["/data"]
+
+EXPOSE 8000
+
+# 스키마는 startup의 create_all이 아니라 Alembic을 정본으로 삼는다.
+# 컨테이너 기동 시 마이그레이션을 먼저 적용한 뒤 서버를 띄운다.
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1"]


### PR DESCRIPTION
## 목적

배포 준비 작업을 `main`으로 승격한다.

## 포함 내용

- 배포용 Dockerfile / 설정 파일
- clair-ai: 미사용 ML 의존성 제거(torch 등 357MB), 데이터 경로 `CLAIR_AI_DATA_DIR`로 설정화
- clair-backend: WeasyPrint 런타임 라이브러리 + 한글 폰트, Alembic 우선 실행
- clair-frontend: SPA 딥링크 rewrite

## 참고

Docker 이미지 빌드는 검증되지 않았다 (작업 환경에 Docker 미설치). 실제 배포 전 확인 필요.
